### PR TITLE
support ESP 8266 (80mHz in COMPATIBILITY_MODE)

### DIFF
--- a/PJON.h
+++ b/PJON.h
@@ -52,7 +52,13 @@ advised of the possibility of such damage. */
   #define PJON_h
 
   #include "Arduino.h"
-  #include "includes/digitalWriteFast.h"
+#ifdef __AVR__
+#  include "includes/digitalWriteFast.h"
+#else
+#  define digitalWriteFast digitalWrite
+#  define digitalReadFast digitalRead
+#  define pinModeFast pinMode
+#endif
 
   /* COMPATIBILITY_MODE set to true:
   Run the network with a cautious speed to support all architectures.
@@ -113,6 +119,14 @@ advised of the possibility of such damage. */
       #define READ_DELAY 15
     #endif
   #endif
+  #if defined(ESP8266) 
+   #if (F_CPU == 80000000L || COMPATIBILITY_MODE) 
+	  #define BIT_WIDTH  44
+	  #define BIT_SPACER 110
+	  #define ACCEPTANCE 35
+	  #define READ_DELAY 4
+   #endif  
+  #endif  
 
 #endif
 

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=PJON is a device communications bus system that connects up to 255 ardu
 paragraph=Provides up to 5KB/s data communication with acknowledge, collision detection, CRC and encpryption all done with micros() and delayMicroseconds(), without using interrupt or timers.
 category=Communication
 url=https://github.com/gioblu/PJON
-architectures=avr
+architectures=avr,esp8266


### PR DESCRIPTION
Hello Giovanni! Would you approve these changes to get compatibility with ESP8266 in (80mHz in COMPATIBILITY_MODE).
I've tested it on ESP-8266 ( in the company of 8266-v.1, 8266-v.7, and Arduino uno v3).
Of course, in case of interact with 5v boards, it needs to use ttl 5-3.3 converter. I used BSS138 with pulldonw (instead of pullup) resistors - works absolutely fine! Actually, it works even in case of direct pin connection, but it's wrong apporoach.
One more thing - ESP8266 will not work with your examples with 10s synconous cycle - it reboots. Just change this time to 1 or 2 seconds, or put yelds in the cycle.
If you interested in this, I could make two level COMPATIBILITY_MODE (8mhZ,16mhz).
With regards, Alexey Grishin.
240974a@gmail.com
