### PR TITLE
Support for Arduino Zero

### DIFF
--- a/PJON.h
+++ b/PJON.h
@@ -48,6 +48,42 @@ theory of liability, whether in contract, strict liability, or tort (including
 negligence or otherwise) arising in any way out of the use of this software, even if
 advised of the possibility of such damage. */
 
+/* modified 2016-03-09 by Esben Soeltoft
+
+   - Added support for the Arduino Zero. 
+     Able to achieve the following speeds between two Arduino Zero
+       Absolute com speed: 5215.20B/s
+       Practical bandwidth: 4346.00B/s
+       Packets sent: 2173.00
+       Mistakes (error found with CRC) 0.00
+       Fail (no answer from receiver) 0
+       Busy (Channel is busy or affected by interference) 0
+       Accuracy: 100.00 %  
+   
+   - All comparison typecasted to preserve proper format between platforms. Comparisons
+     on AVR defaults to 16 bit unless typecasted, while it defaults to 32 bits on SAMD
+     This can give problems when comparison is made with timer functions such as millis(),
+     micros(), delay() and delaymicroseconds().
+     The function micros() and millis() both returns a unsigned long (uint32_t) on AVR and SAMD.
+     Delay argument is typecasted (unsigned long) or (uint32_t) on AVR, and delaymicroseconds argument 
+     is typecasted (unsigned int) or (uint16_t) on AVR, while on SAMD the delay argument is typecasted 
+     (uint32_t), and delaymicroseconds argument is typecasted (uint32_t).
+
+   - #endif belonging to #ifndef PJON_h moved to end of file
+
+   - in function receive_byte, the functioncall digitalWriteFast(_input_pin,LOW) has been removed. It
+     should not be necessary when the _input_pin is pulled low using a pulldown resistor. Having this
+     second line only slows down.
+     If the physical pulldown resistor has to be avoided, pinModeFast(_input_pin,INPUT_PULLDOWN) will
+     be the correct function call to use, as the INPUT_PULLDOWN is done through pinMode and not
+     digitalWriteFast.
+     
+   TO-DO
+   - Reduce variable size to optimize memory footprint
+
+*/
+
+
 #ifndef PJON_h
   #define PJON_h
 
@@ -62,59 +98,68 @@ advised of the possibility of such damage. */
   indicated only for networks made by a group of devices with the
   same architecture / processor (for example 10 Arduino Uno) */
 
-  #define  COMPATIBILITY_MODE true
+  #define  COMPATIBILITY_MODE false
 
   /* The following constants setup are quite conservative and determined only
      with a huge amount of time and blind testing (without oscilloscope)
      tweaking values and analysing results. Theese can be changed to obtain
      faster speed. Probably you need experience, time and an oscilloscope. */
 
-  #if defined(__AVR_ATmega88__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
-    #if (F_CPU == 16000000 && !COMPATIBILITY_MODE)
-      #define BIT_WIDTH 20
-      #define BIT_SPACER 56
-      #define ACCEPTANCE 20
-      #define READ_DELAY 8
-    #endif
-    #if (F_CPU == 8000000 || COMPATIBILITY_MODE)
-      #define BIT_WIDTH 40
-      #define BIT_SPACER 112
-      #define ACCEPTANCE 40
-      #define READ_DELAY 4
-    #endif
-  #endif
 
-  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-    #if (F_CPU == 16000000 && !COMPATIBILITY_MODE)
-      /* Mega has shorter values than Duemianove / Uno because
-      micros() produces longer delays on ATmega1280/2560 */
+  #if (COMPATIBILITY_MODE)
+    #define BIT_WIDTH 40
+    #define BIT_SPACER 112
+    #define ACCEPTANCE 40
+    #define READ_DELAY 4
+  #else
+    /* Values known to work
+       BIT_WIDTH 18
+       BIT_SPACER 54
+       ACCEPTANCE 18
+       READ_DELAY 8
+    */
+    #if defined(ARDUINO_SAMD_ZERO ) 
+      #define BIT_WIDTH 14
+      #define BIT_SPACER 42
+      #define ACCEPTANCE 14
+      #define READ_DELAY 4
+/*    #elif ( (F_CPU == 48000000)|| defined(ARDUINO_ARCH_SAMD) || defined(__SAMD21G18A__) )
       #define BIT_WIDTH 18
       #define BIT_SPACER 54
       #define ACCEPTANCE 18
-      #define READ_DELAY 8
-    #endif
-    #if (F_CPU == 8000000 || COMPATIBILITY_MODE)
-      /* Mega has shorter values than Duemianove / Uno because
-      micros() produces longer delays on ATmega1280/2560 */
-      #define BIT_WIDTH 38
-      #define BIT_SPACER 110
-      #define ACCEPTANCE 38
-      #define READ_DELAY 16
-    #endif
-  #endif
-
-  #if defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
-    #if (F_CPU == 8000000 || COMPATIBILITY_MODE) // Internal clock
+      #define READ_DELAY 8 */
+    #elif defined(__AVR_ATmega88__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
+      #if ( F_CPU == 16000000 )
+        /* Mega has shorter values than Duemianove / Uno because
+        micros() produces longer delays on ATmega1280/2560 */      
+        #define BIT_WIDTH 18
+        #define BIT_SPACER 54
+        #define ACCEPTANCE 18
+        #define READ_DELAY 8
+      #else  // internal clock 8000000
+        #define BIT_WIDTH 38
+        #define BIT_SPACER 110
+        #define ACCEPTANCE 38
+        #define READ_DELAY 16
+      #endif
+    #elif defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+      // Internal clock F_CPU == 80000
       /* ATtiny has shorter values than Duemianove / Uno because
       micros() produces longer delays on ATtiny45/85 */
       #define BIT_WIDTH  35
       #define BIT_SPACER 107
       #define ACCEPTANCE 35
       #define READ_DELAY 15
-    #endif
+    #else
+      #define BIT_WIDTH 40
+      #define BIT_SPACER 112
+      #define ACCEPTANCE 40
+      #define READ_DELAY 4    
+    #endif            
   #endif
 
-#endif
+
+ 
 
 // Protocol symbols
 #define ACK        6
@@ -144,9 +189,9 @@ struct packet {
   uint8_t device_id;
   char *content;
   uint8_t length;
-  unsigned long registration;
-  int state;
-  unsigned long timing;
+  uint32_t registration;
+  uint16_t state;
+  uint32_t timing;
 };
 
 typedef void (* receiver)(uint8_t length, uint8_t *payload);
@@ -158,8 +203,8 @@ static void dummy_receiver_handler(uint8_t length, uint8_t *payload) {};
 class PJON {
 
   public:
-    PJON(int input_pin);
-    PJON(int input_pin, uint8_t id);
+    PJON(uint8_t input_pin);
+    PJON(uint8_t input_pin, uint8_t id);
 
     void initialize();
 
@@ -168,17 +213,17 @@ class PJON {
     void set_receiver(receiver r);
     void set_error(error e);
 
-    int receive_byte();
-    int receive();
-    int receive(unsigned long duration);
+    uint16_t receive_byte();
+    uint16_t receive();
+    uint16_t receive(uint32_t duration);
 
-    void send_bit(uint8_t VALUE, int duration);
+    void send_bit(uint8_t VALUE, uint32_t duration);
     void send_byte(uint8_t b);
-    int  send_string(uint8_t id, char *string, uint8_t length);
-    int  send(uint8_t id, char *packet, uint8_t length, unsigned long timing = 0);
+    uint16_t  send_string(uint8_t id, char *string, uint8_t length);
+    uint16_t  send(uint8_t id, char *packet, uint8_t length, uint32_t timing = 0);
 
     void update();
-    void remove(int id);
+    void remove(uint16_t id);
 
     uint8_t read_byte();
     boolean can_start();
@@ -190,7 +235,8 @@ class PJON {
 
   private:
     uint8_t   _device_id;
-    int       _input_pin;
+    uint8_t   _input_pin;
     receiver  _receiver;
     error     _error;
 };
+#endif

--- a/includes/digitalWriteFast.h
+++ b/includes/digitalWriteFast.h
@@ -31,22 +31,222 @@
    negligence or otherwise) arising in any way out of the use of this software, even if
    advised of the possibility of such damage. */
 
-#if defined(ARDUINO) && (ARDUINO >= 100)
-  #include "Arduino.h"
-#else
-  #include "WProgram.h"
-  #include <wiring.h>
-#endif
+/* 2016-03-09 update by Esben Soeltoft
+   This update includes:
+   
+    - support for the SAMD Arduino Zero from arduino.cc
+      has been able to achieve the following speed by doing the relevant function call
+      500 times and comparing the time before and after.
+        Time for digitalWrite(): 1282
+        Time for digitalWriteFast(): 90
+        Time for digitalRead(): 400
+        Time for digitalReadFast(): 67
+        Time for pinMode(  ,INPUT): 926
+        Time for pinMode(  ,INPUT_PULLDOWN): 1033
+        Time for pinModeFast(  ,INPUT): 91
+        Time for pinModeFast(  ,INPUT_PULLDOWN): 308
+     
+      It is worth observing that normal INPUT is more than 3 times faster than INPUT_PULLDOWN
+      
+    - removed local BITREAD function to utilize bitRead() function from Arduino.h include
+    
+    - the method for INPUT_PULLDOWN and INPUT_PULLUP was changed from digitalWriteFast to
+      pinModeFast to function according to original arduino functions.
 
-#define BIT_READ(value, bit) (((value) >> (bit)) & 0x01)
-#define BIT_SET(value, bit) ((value) |= (1UL << (bit)))
-#define BIT_CLEAR(value, bit) ((value) &= ~(1UL << (bit)))
-#define BIT_WRITE(value, bit, bitvalue) (bitvalue ? BIT_SET(value, bit) : BIT_CLEAR(value, bit))
+    - Added include guard for this library
+    
+    - Added a library comment explaining when the library can boost performance.
 
-#if !defined(digitalPinToPortReg)
-  #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-    // Arduino Mega Pins
-    #define digitalPinToPortReg(P) \
+   TO-DO
+    - modify pinModeFast for AVR to set INPUT_PULLDOWN and INPUT_PULLUP correctly instead
+      of in digitalWriteFast.
+      
+    - rewrite pinModeFast for SAMD to improve the read-write operations speed on the registers
+    
+*/
+   
+
+
+//==================================================================
+// include guard
+#ifndef __DIGITALWRITEFAST_H_INCLUDED__
+#define __DIGITALWRITEFAST_H_INCLUDED__
+
+/* What can this library accomplish
+   If a pin number is known at compile time, it can speed up digital write and read functions.
+   e.g. that digitalWrite(11,HIGH) is speeded up by using digitalWriteFast(11,HIGH). 
+   On the other hand if digitalWrite is called like this digitalWrite(i,HIGH) such as in a loop
+   or in a function call with the pin number as a passed argument digitalWriteFast(i,HIGH) will 
+   not be faster, as it will need to fall back to the normal digitalWrite() funtion.
+ */
+
+//==================================================================
+// include arduino header files to get bitRead included
+  #if defined(ARDUINO) && (ARDUINO >= 100)
+    #include "Arduino.h"
+  #else
+    #include "WProgram.h"
+    #include <wiring.h>
+  #endif
+
+
+  #if defined(__SAMD21G18A__) || defined(ARDUINO_SAM_ZERO)
+    //==================================================================
+    // pin mapping for SAMD chips
+  
+    // Arduino Zero pins
+    //D0 - PORT_PA11
+    //D1 - PORT_PA10
+    //D2 - PORT_PA14   
+    //D3 - PORT_PA09
+    //D4 - PORT_PA08   
+    //D5 - PORT_PA15
+    //D6 - PORT_PA20
+    //D7 - PORT_PA21
+    //D8 - PORT_PA06
+    //D9 - PORT_PA07
+    //D10 - PORT_PA18
+    //D11 - PORT_PA16
+    //D12 - PORT_PA19
+    //D13 - PORT_PA17
+
+    //A0 - PORT_PA02
+    //A1 - PORT_PB08
+    //A2 - PORT_PB09
+    //A3 - PORT_PA04
+    //A4 - PORT_PA05
+    //A5 - PORT_PB02
+
+    //SCK - PORT_PB11
+    //MISO - PORT_PA12
+    //MOSI - PORT_PB10
+
+    //SCL - PORT_PB23
+    //SDA - PORT_PB22
+
+    //ATN - PORT_PA13    
+
+
+    #define __digitalPinToPortBit(P) \
+    (((P) == 0) ? PORT_PA11  : \
+    (((P) == 1) ? PORT_PA10  : \
+    (((P) == 2) ? PORT_PA14  : \
+    (((P) == 3) ? PORT_PA09  : \
+    (((P) == 4) ? PORT_PA08  : \
+    (((P) == 5) ? PORT_PA15  : \
+    (((P) == 6) ? PORT_PA20  : \
+    (((P) == 7) ? PORT_PA21  : \
+    (((P) == 8) ? PORT_PA06  : \
+    (((P) == 9) ? PORT_PA07  : \
+    (((P) == 10) ? PORT_PA18 : \
+    (((P) == 11) ? PORT_PA16 : \
+    (((P) == 12) ? PORT_PA19 : \
+    (((P) == 13) ? PORT_PA17 : \
+    (((P) == A0) ? PORT_PA02 : \
+    (((P) == A1) ? PORT_PB08 : \
+    (((P) == A2) ? PORT_PB09 : \
+    (((P) == A3) ? PORT_PA04 : \
+    (((P) == A4) ? PORT_PA05 : \
+    (((P) == A5) ? PORT_PB02 : \
+    (((P) == SCK) ? PORT_PB11  : \
+    (((P) == MISO) ? PORT_PA12 : \
+    (((P) == MOSI) ? PORT_PB10 : \
+    (((P) == PIN_WIRE_SCL) ? PORT_PA23 : \
+    (((P) == PIN_WIRE_SDA) ? PORT_PA22 : PORT_PA13)))))))))))))))))))))))))
+
+    #define __digitalPinToPortReg(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? PORTB : PORTA )
+
+    #define __digitalPinToPortRegOUT(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_OUT1 : REG_PORT_OUT0 )
+
+    #define __digitalPinToPortRegOUTSET(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_OUTSET1 : REG_PORT_OUTSET0 )
+
+    #define __digitalPinToPortRegOUTCLR(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_OUTCLR1 : REG_PORT_OUTCLR0 )
+
+    #define __digitalPinToPortRegPINCFG(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_PINCFG1 : REG_PORT_PINCFG0 )
+
+    #define __digitalPinToPortRegDIRSET(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_DIRSET1 : REG_PORT_DIRSET0 )
+
+    #define __digitalPinToPortRegDIRCLR(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_DIRCLR1 : REG_PORT_DIRCLR0 )
+
+    #define __digitalPinToPortINReg(P) \
+    (((P) >= 15 && (P) <= 16) || ((P) == 19 ) || ((P) >= 23 && (P) <= 24) ? REG_PORT_IN1 : REG_PORT_IN0 )
+
+
+   
+    
+    //==================================================================
+    // functions for read/write/pinmode fast for SAMD chips
+
+    // PWM pins 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 provide 8-bit PWM output with the analogWrite() function
+    // analogWrite works on all analog pins and all digital PWM pins. You can supply it any value between 0 and 255.
+    // analog pins provide 12bits resolution and provide a value between 0-4096.
+
+
+    /*
+     * INPUT           (0x0)
+     * OUTPUT          (0x1)
+     * INPUT_PULLUP    (0x2) Set pin to input mode with pull-up resistor enabled
+     * INPUT_PULLDOWN  (0x3)
+     */
+    
+    #define pinModeFast(P, V)                                                                                 \
+      do {                                                                                                    \
+        if (__builtin_constant_p(P) && __builtin_constant_p(V)){                                              \
+          if((V == 0x0)){                                                                                     \
+            __digitalPinToPortRegPINCFG(P) = (uint8_t)(PORT_PINCFG_INEN) ;                                    \
+            __digitalPinToPortRegDIRCLR(P) = (uint32_t)__digitalPinToPortBit(P) ;                             \
+          }else if((V == 0x2)){                                                                               \
+            PORT->Group[__digitalPinToPortReg(11)].PINCFG[g_APinDescription[11].ulPin].reg=(uint8_t)(PORT_PINCFG_INEN|PORT_PINCFG_PULLEN) ;  \
+            __digitalPinToPortRegDIRCLR(P) = (uint32_t)__digitalPinToPortBit(P) ;                             \
+            /* Enable pull level (cf '22.6.3.2 Input Configuration' and '22.8.7 Data Output Value Set')*/     \
+            __digitalPinToPortRegOUTSET(P) = (uint32_t)__digitalPinToPortBit(P) ;                             \
+          }else if((V == 0x3)){                                                                               \
+            PORT->Group[g_APinDescription[11].ulPort].PINCFG[g_APinDescription[11].ulPin].reg=(uint8_t)(PORT_PINCFG_INEN|PORT_PINCFG_PULLEN) ; \
+            __digitalPinToPortRegDIRCLR(P) = (uint32_t)__digitalPinToPortBit(P) ;                             \
+            /* Enable pull level (cf '22.6.3.2 Input Configuration' and '22.8.6 Data Output Value Clear') */  \
+            __digitalPinToPortRegOUTCLR(P) = (uint32_t)__digitalPinToPortBit(P) ;                             \
+          }else{                                                                                              \
+            __digitalPinToPortRegPINCFG(P) &= ~(uint8_t)(PORT_PINCFG_INEN) ;                                  \
+            __digitalPinToPortRegDIRSET(P) = (uint32_t)__digitalPinToPortBit(P) ;                             \
+          }                                                                                                   \
+        }else                                                                                                 \
+          pinMode((P), (V));                                                                                  \
+      }while (0)
+
+
+    #define digitalReadFast(P) ( (int) _digitalReadFast_((P)) )
+	  #define _digitalReadFast_(P) (__builtin_constant_p(P) ) ? ( __digitalPinToPortINReg(P) & __digitalPinToPortBit(P) ) : digitalRead((P))
+
+
+    #define digitalWriteFast(P, V)                                        \
+      do {                                                                \
+        if (__builtin_constant_p(P) && __builtin_constant_p(V)){          \
+          if((V))                                                         \
+            __digitalPinToPortRegOUTSET(P) = __digitalPinToPortBit(P);    \
+          else                                                            \
+            __digitalPinToPortRegOUTCLR(P) = __digitalPinToPortBit(P);    \
+        }else                                                             \
+          digitalWrite((P), (V));                                         \
+      }while (0)
+
+
+    // Arduino Zero done
+
+
+  #else
+    //==================================================================
+    // pin mapping for AVR chips
+      
+    #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+      // Arduino Mega pins
+      #define digitalPinToPortReg(P) \
       (((P) >= 22 && (P) <= 29) ? &PORTA : \
       ((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &PORTB : \
       (((P) >= 30 && (P) <= 37) ? &PORTC : \
@@ -56,9 +256,9 @@
       ((((P) >= 39 && (P) <= 41) || (P) == 4) ? &PORTG : \
       ((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &PORTH : \
       (((P) == 14 || (P) == 15) ? &PORTJ : \
-      (((P) >= 62 && (P) <= 69) ? &PORTK : &PORTL))))))))))
+      (((P) >= 62 && (P) <= 69) ? &PORTK : &PORTL))))))))))  
 
-    #define digitalPinToDDRReg(P) \
+      #define digitalPinToDDRReg(P) \
       (((P) >= 22 && (P) <= 29) ? &DDRA : \
       ((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &DDRB : \
       (((P) >= 30 && (P) <= 37) ? &DDRC : \
@@ -70,7 +270,7 @@
       (((P) == 14 || (P) == 15) ? &DDRJ : \
       (((P) >= 62 && (P) <= 69) ? &DDRK : &DDRL))))))))))
 
-    #define digitalPinToPINReg(P) \
+      #define digitalPinToPINReg(P) \
       (((P) >= 22 && (P) <= 29) ? &PINA : \
       ((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &PINB : \
       (((P) >= 30 && (P) <= 37) ? &PINC : \
@@ -82,7 +282,7 @@
       (((P) == 14 || (P) == 15) ? &PINJ : \
       (((P) >= 62 && (P) <= 69) ? &PINK : &PINL))))))))))
 
-    #define __digitalPinToBit(P) \
+      #define __digitalPinToBit(P) \
       (((P) >=  7 && (P) <=  9) ? (P) - 3 : \
       (((P) >= 10 && (P) <= 13) ? (P) - 6 : \
       (((P) >= 22 && (P) <= 29) ? (P) - 22 : \
@@ -99,110 +299,105 @@
       (((P) == 2) ? 4 : \
       (((P) == 3 || (P) == 4) ? 5 : 7)))))))))))))))
 
-    // 15 PWM
-    #define __digitalPinToTimer(P) \
+      // 15 PWM pins
+      #define __digitalPinToTimer(P) \
       (((P) == 13 || (P) ==  4) ? &TCCR0A : \
       (((P) == 11 || (P) == 12) ? &TCCR1A : \
       (((P) == 10 || (P) ==  9) ? &TCCR2A : \
       (((P) ==  5 || (P) ==  2 || (P) ==  3) ? &TCCR3A : \
       (((P) ==  6 || (P) ==  7 || (P) ==  8) ? &TCCR4A : \
       (((P) == 46 || (P) == 45 || (P) == 44) ? &TCCR5A : 0))))))
-
-    #define __digitalPinToTimerBit(P) \
+      #define __digitalPinToTimerBit(P) \
       (((P) == 13) ? COM0A1 : (((P) ==  4) ? COM0B1 : \
       (((P) == 11) ? COM1A1 : (((P) == 12) ? COM1B1 : \
       (((P) == 10) ? COM2A1 : (((P) ==  9) ? COM2B1 : \
       (((P) ==  5) ? COM3A1 : (((P) ==  2) ? COM3B1 : (((P) ==  3) ? COM3C1 : \
       (((P) ==  6) ? COM4A1 : (((P) ==  7) ? COM4B1 : (((P) ==  8) ? COM4C1 : \
       (((P) == 46) ? COM5A1 : (((P) == 45) ? COM5B1 : COM5C1))))))))))))))
-
-  #else
-
-    #if defined(__AVR_ATmega8__) // PWM ATmega 8
-      #define __digitalPinToTimer(P) \
-      (((P) ==  9 || (P) == 10) ? &TCCR1A : (((P) == 11) ? &TCCR2 : 0))
-      #define __digitalPinToTimerBit(P) \
-      (((P) ==  9) ? COM1A1 : (((P) == 10) ? COM1B1 : COM21))
-    #endif
-
-    #if defined(__AVR_ATmega88__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
+      
+      // end Arduino Mega
+    #else
+      // Standard Arduino Pins
       #define digitalPinToPortReg(P) \
-        (((P) >= 0 && (P) <= 7) ? &PORTD : (((P) >= 8 && (P) <= 13) ? &PORTB : &PORTC))
-
+      (((P) >= 0 && (P) <= 7) ? &PORTD : (((P) >= 8 && (P) <= 13) ? &PORTB : &PORTC))
       #define digitalPinToDDRReg(P) \
-        (((P) >= 0 && (P) <= 7) ? &DDRD : (((P) >= 8 && (P) <= 13) ? &DDRB : &DDRC))
-
+      (((P) >= 0 && (P) <= 7) ? &DDRD : (((P) >= 8 && (P) <= 13) ? &DDRB : &DDRC))
       #define digitalPinToPINReg(P) \
-        (((P) >= 0 && (P) <= 7) ? &PIND : (((P) >= 8 && (P) <= 13) ? &PINB : &PINC))
-
+      (((P) >= 0 && (P) <= 7) ? &PIND : (((P) >= 8 && (P) <= 13) ? &PINB : &PINC))
       #define __digitalPinToBit(P) \
-        (((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P) - 8 : (P) - 14))
+      (((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P) - 8 : (P) - 14))
 
-      // 6 PWM
-      #define __digitalPinToTimer(P) \
-      (((P) ==  6 || (P) ==  5) ? &TCCR0A : \
-      (((P) ==  9 || (P) == 10) ? &TCCR1A : \
-      (((P) == 11 || (P) ==  3) ? &TCCR2A : 0)))
+      #if defined(__AVR_ATmega8__)
+        // 3 PWM pins
+        #define __digitalPinToTimer(P) \
+        (((P) ==  9 || (P) == 10) ? &TCCR1A : (((P) == 11) ? &TCCR2 : 0))
+        #define __digitalPinToTimerBit(P) \
+        (((P) ==  9) ? COM1A1 : (((P) == 10) ? COM1B1 : COM21))
+        #else  //168,328
 
-      #define __digitalPinToTimerBit(P) \
-      (((P) ==  6) ? COM0A1 : (((P) ==  5) ? COM0B1 : \
-      (((P) ==  9) ? COM1A1 : (((P) == 10) ? COM1B1 : \
-      (((P) == 11) ? COM2A1 : COM2B1)))))
-    #endif
+        // 6 PWM pins
+        #define __digitalPinToTimer(P) \
+        (((P) ==  6 || (P) ==  5) ? &TCCR0A : \
+        (((P) ==  9 || (P) == 10) ? &TCCR1A : \
+        (((P) == 11 || (P) ==  3) ? &TCCR2A : 0)))
+        #define __digitalPinToTimerBit(P) \
+        (((P) ==  6) ? COM0A1 : (((P) ==  5) ? COM0B1 : \
+        (((P) ==  9) ? COM1A1 : (((P) == 10) ? COM1B1 : \
+        (((P) == 11) ? COM2A1 : COM2B1)))))
+        
+        
+      #endif // end defined(__AVR_ATmega8__)
+    #endif // end Standard Arduino pins
 
-    #if defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
-      #define digitalPinToPortReg(P) \
-        &PORTB
+    //==================================================================
+    // functions to read/write/pinMode fast for AVR chips
+    #define __atomicWrite__(A,P,V) \
+    if ( (int)(A) < 0x40) { bitWrite(*(A), __digitalPinToBit(P), (V) );}  \
+    else {                                                                \
+      uint8_t register saveSreg = SREG;                                   \
+      cli();                                                              \
+      bitWrite(*(A), __digitalPinToBit(P), (V) );                         \
+      SREG=saveSreg;                                                      \
+    } 
 
-      #define digitalPinToDDRReg(P) \
-        &DDRB
 
-      #define digitalPinToPINReg(P) \
-        &PINB
+    #ifndef digitalWriteFast
+    #define digitalWriteFast(P, V)                                        \
+      do {                                                                \
+        if (__builtin_constant_p(P) && __builtin_constant_p(V))           \
+          __atomicWrite__((uint8_t*) digitalPinToPortReg(P),P,V)          \
+        else                                                              \
+          digitalWrite((P), (V));                                         \
+      }while (0)
+    #endif  //#ifndef digitalWriteFast
 
-      #define __digitalPinToBit(P) \
-        P - 6
-    #endif
+    #if !defined(pinModeFast)
+    #define pinModeFast(P, V) \
+      do {  \
+        if (__builtin_constant_p(P) && __builtin_constant_p(V)) __atomicWrite__((uint8_t*) digitalPinToDDRReg(P),P,V) \
+        else pinMode((P), (V)); \
+      } while (0)
+    #endif  //#ifndef pinModeFast
+
+
+    #ifndef noAnalogWrite
+    #define noAnalogWrite(P) \
+	    do {  \
+        if (__builtin_constant_p(P) )  __atomicWrite((uint8_t*) __digitalPinToTimer(P),P,0) \
+		    else turnOffPWM((P));   \
+    } while (0)
+    #endif  //#ifndef noAnalogWrite		
+
+
+    #ifndef digitalReadFast
+	    #define digitalReadFast(P) ( (int) _digitalReadFast_((P)) )
+	    #define _digitalReadFast_(P ) \
+	    (__builtin_constant_p(P) ) ? ( \
+	    ( bitRead(*digitalPinToPINReg(P), __digitalPinToBit(P))) ) : \
+	    digitalRead((P))
+    #endif  //#ifndef digitalReadFast
 
   #endif
-#endif
 
 
-#define __atomicWrite__(A,P,V) \
-  if ( (int)(A) < 0x40) { bitWrite(*(A), __digitalPinToBit(P), (V) );}  \
-  else { \
-    uint8_t register saveSreg = SREG; \
-    cli(); \
-    bitWrite(*(A), __digitalPinToBit(P), (V) ); \
-    SREG=saveSreg; \
-  }
-
-#ifndef digitalWriteFast
-  #define digitalWriteFast(P, V) \
-    do { \
-      if (__builtin_constant_p(P) && __builtin_constant_p(V))   __atomicWrite__((uint8_t*) digitalPinToPortReg(P),P,V) \
-      else  digitalWrite((P), (V)); \
-    } while (0)
-#endif  //#ifndef digitalWriteFast2
-
-#if !defined(pinModeFast)
-  #define pinModeFast(P, V) \
-  do { if (__builtin_constant_p(P) && __builtin_constant_p(V)) __atomicWrite__((uint8_t*) digitalPinToDDRReg(P),P,V) \
-    else pinMode((P), (V)); \
-  } while (0)
-#endif
-
-#ifndef noAnalogWrite
-  #define noAnalogWrite(P) \
-  	do { if (__builtin_constant_p(P) )  __atomicWrite((uint8_t*) __digitalPinToTimer(P),P,0) \
-  		else turnOffPWM((P)); \
-    } while (0)
-#endif
-
-#ifndef digitalReadFast
-	#define digitalReadFast(P) ( (int) _digitalReadFast_((P)) )
-	#define _digitalReadFast_(P ) \
-  	(__builtin_constant_p(P) ) ? ( \
-  	( BIT_READ(*digitalPinToPINReg(P), __digitalPinToBit(P))) ) : \
-  	digitalRead((P))
-#endif
+#endif  // __DIGITALWRITEFAST_H_INCLUDED__

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=PJON is a device communications bus system that connects up to 255 ardu
 paragraph=Provides up to 5KB/s data communication with acknowledge, collision detection, CRC and encpryption all done with micros() and delayMicroseconds(), without using interrupt or timers.
 category=Communication
 url=https://github.com/gioblu/PJON
-architectures=avr
+architectures=avr,samd


### PR DESCRIPTION
Modified PJON.cpp and PJON.h
   - Added support for the Arduino Zero. 
     Able to achieve the following speeds between two Arduino Zero
       Absolute com speed: 5215.20B/s
       Practical bandwidth: 4346.00B/s
       Packets sent: 2173.00
       Mistakes (error found with CRC) 0.00
       Fail (no answer from receiver) 0
       Busy (Channel is busy or affected by interference) 0
       Accuracy: 100.00 %  
   
   - All comparison typecasted to preserve proper format between platforms. Comparisons
     on AVR defaults to 16 bit unless typecasted, while it defaults to 32 bits on SAMD
     This can give problems when comparison is made with timer functions such as millis(),
     micros(), delay() and delaymicroseconds().
     The function micros() and millis() both returns a unsigned long (uint32_t) on AVR and SAMD.
     Delay argument is typecasted (unsigned long) or (uint32_t) on AVR, and delaymicroseconds argument 
     is typecasted (unsigned int) or (uint16_t) on AVR, while on SAMD the delay argument is typecasted 
     (uint32_t), and delaymicroseconds argument is typecasted (uint32_t).

   - #endif belonging to #ifndef PJON_h moved to end of file

   - in function receive_byte, the functioncall digitalWriteFast(_input_pin,LOW) has been removed. It
     should not be necessary when the _input_pin is pulled low using a pulldown resistor. Having this
     second line only slows down.
     If the physical pulldown resistor has to be avoided, pinModeFast(_input_pin,INPUT_PULLDOWN) will
     be the correct function call to use, as the INPUT_PULLDOWN is done through pinMode and not
     digitalWriteFast.

Modified library.properties 
  - Added support for samd architecture.

Modified /includes/digitalWriteFast.h
   
    - support for the SAMD Arduino Zero from arduino.cc
      has been able to achieve the following speed by doing the relevant function call
      500 times and comparing the time before and after.
        Time for digitalWrite(): 1282
        Time for digitalWriteFast(): 90
        Time for digitalRead(): 400
        Time for digitalReadFast(): 67
        Time for pinMode(  ,INPUT): 926
        Time for pinMode(  ,INPUT_PULLDOWN): 1033
        Time for pinModeFast(  ,INPUT): 91
        Time for pinModeFast(  ,INPUT_PULLDOWN): 308
     
      It is worth observing that normal INPUT is more than 3 times faster than INPUT_PULLDOWN
      
    - removed local BITREAD function to utilize bitRead() function from Arduino.h include
    
    - the method for INPUT_PULLDOWN and INPUT_PULLUP was changed from digitalWriteFast to
      pinModeFast to function according to original arduino functions.

    - Added include guard for this library
    
    - Added a library comment explaining when the library can boost performance.
