### PR TITLE
Let the crawler auto-resolve released versions from github tags

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/gioblu/PJON.git"
   },
   "examples": "examples/*/*/*.ino",
-  "version": "2.0",
   "frameworks": "arduino",
   "platforms":
   [


### PR DESCRIPTION
Specifying a version in the descriptor locks things at a specific release. Let PlatformIO crawler scan the tags regularly and update automatically.