### PR TITLE
Fix some compiler warnings

### DIFF
--- a/PJON.cpp
+++ b/PJON.cpp
@@ -291,7 +291,7 @@ uint16_t PJON::send_string(uint8_t id, char *string, uint8_t length) {
   | device_id | length | content | state | attempts | timing | registration |
   |___________|________|_________|_______|__________|________|______________| */
 
-uint16_t PJON::send(uint8_t id, char *packet, uint8_t length, uint32_t timing) {
+uint16_t PJON::send(uint8_t id, const char *packet, uint8_t length, uint32_t timing) {
 
   if(length >= PACKET_MAX_LENGTH) {
     this->_error(CONTENT_TOO_LONG, length);

--- a/PJON.h
+++ b/PJON.h
@@ -98,8 +98,6 @@ limitations under the License. */
 
   typedef void (* receiver)(uint8_t length, uint8_t *payload);
   typedef void (* error)(uint8_t code, uint8_t data);
-  static void dummy_error_handler(uint8_t code, uint8_t data) {};
-  static void dummy_receiver_handler(uint8_t length, uint8_t *payload) {};
 
   class PJON {
     public:

--- a/PJON.h
+++ b/PJON.h
@@ -114,7 +114,7 @@ limitations under the License. */
       uint16_t  receive(uint32_t duration);
       uint16_t  receive_byte();
       void      remove(uint16_t id);
-      uint16_t  send(uint8_t id, char *packet, uint8_t length, uint32_t timing = 0);
+      uint16_t  send(uint8_t id, const char *packet, uint8_t length, uint32_t timing = 0);
       void      send_byte(uint8_t b);
       uint16_t  send_string(uint8_t id, char *string, uint8_t length);
       void      set_default();


### PR DESCRIPTION
This fixes some compiler warnings.
- move dummy handler to c file (no need to put this into the header)
- NULL is a actually '(void*)0' and shouldn't be used on non-pointer types.
- const correctness for send function
- FAIL is set to 0x100 which is bigger than max of uint8
- fixed potentially unintialized return code