### PR TITLE
Allow to modify reserved addresses (BROADCAST and NOT_DEFINIED)

### DIFF
--- a/PJON.h
+++ b/PJON.h
@@ -39,10 +39,14 @@ limitations under the License. */
   /* Protocol symbols */
   #define ACK           6
   #define ACQUIRE_ID    63
-  #define BROADCAST     0
   #define BUSY          666
   #define NAK           21
   #define NOT_ASSIGNED  255
+  /* Set broadcast address to 0 if not defined other */
+  #ifndef BROADCAST
+      #define BROADCAST     0
+  #endif
+
 
   /* A bus id is an array of 4 bytes containing a unique set.
       The default setting is to run a local bus (0.0.0.0), in this

--- a/PJON.h
+++ b/PJON.h
@@ -49,7 +49,6 @@ limitations under the License. */
       particular case the obvious bus id is omitted from the packet
       content to reduce overhead. */
 
-  uint8_t localhost[4] = {0, 0, 0, 0};
 
   /* Internal constants */
   #define FAIL          0x100
@@ -99,6 +98,7 @@ limitations under the License. */
   class PJON {
 
     Strategy strategy;
+    uint8_t localhost[4] = {0, 0, 0, 0};
 
     public:
 
@@ -156,6 +156,10 @@ limitations under the License. */
         }
         _error(ID_ACQUISITION_FAIL, FAIL);
       };
+
+      void set_network(uint8_t *addr) {
+        localhost = addr;
+      }
 
 
       /* Initial random delay to avoid startup collision */


### PR DESCRIPTION
Example usage
```c++
#define NOT_ASSIGNED 0
#define BROADCAST 255
#include <PJON.h>
```