### PR TITLE
Please check OverSamplingSimplex example

### DIFF
--- a/examples/Local/OverSamplingSimplex/Receiver/Receiver.ino
+++ b/examples/Local/OverSamplingSimplex/Receiver/Receiver.ino
@@ -10,7 +10,7 @@ int fail;
 PJON<OverSampling> bus(44);
 
 void setup() {
-  bus.set_pin(11);
+  bus.set_pins(11);
   bus.begin();
 
   bus.set_receiver(receiver_function);

--- a/examples/Local/OverSamplingSimplex/Transmitter/Transmitter.ino
+++ b/examples/Local/OverSamplingSimplex/Transmitter/Transmitter.ino
@@ -12,7 +12,7 @@ int packet;
 char content[] = "01234567890123456789";
 
 void setup() {
-  bus.set_pin(12);
+  bus.set_pins(NOT_ASSIGNED, 12);
 
   bus.begin();
   packet = bus.send(44, content, 20);


### PR DESCRIPTION
This example seems not effectively using SIMPLEX communication mode, but it leaves the communication mode to default HALF_DUPLEX, so to switch to SIMPLEX we should unassign
the unused pin, or call set_communication_mode(SIMPLEX)