### PR TITLE
Update io-setup doc with set_communication_mode()

### DIFF
--- a/documentation/io-setup.md
+++ b/documentation/io-setup.md
@@ -21,6 +21,7 @@ If for some reason you need to keep separate the two lines, for example if using
 If you don't need bidirectional communication and you have only the transmitter on one side and the receiver on the other side you can use the `NOT_ASSIGNED` constant:
 ```cpp  
  PJON<OverSampling> bus;
+ bus.strategy.set_communication_mode(SIMPLEX); // Tell PJON we want to operate in Simplex mode
  bus.strategy.set_pins(11, NOT_ASSIGNED); // Only receiver
 ```
 


### PR DESCRIPTION
As suggested in https://github.com/gioblu/PJON/issues/104 it'd be a good idea to illustrate that using NOT_ASSIGNED means that we're necessarily in Simplex mode, which needs to be manually set with bus.strategy.set_communication_mode(SIMPLEX);

Adding it to the example would help new comers to PJON.