### PR TITLE
Added Extender examples

### DIFF
--- a/examples/Local/Extender/Extender/Extender.ino
+++ b/examples/Local/Extender/Extender/Extender.ino
@@ -1,0 +1,98 @@
+/* This sketch will allow a local bus to be segmented. It can be used for:
+   
+   1. Extending a media like a repeater. For example if SWBB wires are getting too long,
+      it can connect two SWBB wires, extending the range. This can be repeated to enable 
+      really long distances.
+   
+   2. Having devices on different media types communicate with each other transparently,
+      for example having devices on a SWBB wire communicate with devices using the LocalUDP
+      strategy on a LAN. Or wired <-> wireless.
+   
+   3. Tunnel packets through another media type by using two extenders mirroring each other. 
+      For example, two SWBB buses that are far from each other can be joined transparently 
+      through a LAN using the LocalUDP strategy, or through a WAN or Internet using the 
+      EthernetTCP strategy. Or join two SWBB local bus segments wirelessly using the OS strategy.
+
+   4. Extend (3) to let packets flow freely between multiple SWBB buses on different media
+      with multiple extenders exchanging the packets on a common media like a LAN with
+      LocalUDP. The buses being connected this way can use a common strategy like SWBB,
+      or different strategies.
+
+   A non-local version of this sketch, connecting two buses with different bus ids,
+   is available as the "Router" sketch among the Network examples.
+*/
+
+#include <PJON.h>
+
+const uint8_t DEVICE_ID = 50;
+
+// <Strategy name> bus(selected device id)
+PJON<SoftwareBitBang> busA(DEVICE_ID);
+PJON<SoftwareBitBang> busB(DEVICE_ID);
+
+// All packets to devices listed here will be forwarded to bus B
+const uint8_t device_id_ranges_on_B_side[] = {10, 19, 
+                                              80, 89};
+const uint8_t single_device_ids_on_B_side[] = {30, 33, 37, 44, 46};
+
+void setup() {
+  Serial.begin(115200);
+  pinMode(13, OUTPUT);
+  digitalWrite(13, LOW); // Initialize LED 13 to be off
+
+  busA.strategy.set_pin(7);
+  busA.set_receiver(receiver_functionA);
+  busA.set_router(true);
+  busA.begin();
+  
+  busB.strategy.set_pin(8);
+  busB.set_receiver(receiver_functionB);
+  busB.set_router(true);
+  busB.begin();
+}
+
+void receiver_functionA(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+  // Forward packet to B segment of local bus
+  if (is_device_on_B_side(packet_info.receiver_id)) {
+    busA.strategy.send_response(PJON_ACK);
+    toggle_led();
+    busB.send_from_id(packet_info.sender_id, packet_info.sender_bus_id, 
+      packet_info.receiver_id, packet_info.receiver_bus_id, payload, length, packet_info.header);
+  }
+}
+
+void receiver_functionB(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+  // Forward packet to A segment of local bus
+  if (!is_device_on_B_side(packet_info.receiver_id)) {
+    busB.strategy.send_response(PJON_ACK);
+    toggle_led();
+    busA.send_from_id(packet_info.sender_id, packet_info.sender_bus_id, 
+      packet_info.receiver_id, packet_info.receiver_bus_id, payload, length, packet_info.header);
+  }
+}
+
+void toggle_led() {
+  static bool led_is_on = false;
+  led_is_on = !led_is_on;
+  digitalWrite(13, led_is_on ? HIGH : LOW);
+}
+
+bool is_device_on_B_side(uint8_t device_id) {
+  // Check if in one of the B ranges
+  for (uint8_t i = 0; i < sizeof device_id_ranges_on_B_side - 1; i += 2)
+    if (device_id_ranges_on_B_side[i] <= device_id && device_id <= device_id_ranges_on_B_side[i+1])
+      return true;
+      
+  // Check if one of the individually registered B side devices    
+  for (uint8_t i = 0; i < sizeof single_device_ids_on_B_side; i++) 
+    if (single_device_ids_on_B_side[i] == device_id) return true;
+    
+  return false;  
+}
+
+void loop() {
+  busA.receive(1000);
+  busB.update();
+  busB.receive(1000);
+  busA.update();
+};

--- a/examples/Local/Extender/README.md
+++ b/examples/Local/Extender/README.md
@@ -1,0 +1,38 @@
+## Extender examples
+
+This sketch will allow a local bus to be segmented. It can be used for:  
+1. Extending a media like a repeater. For example if SWBB wires are getting too long, it can connect two SWBB wires, extending the range. This can be repeated to enable  really long distances.
+2. Having devices on different media types communicate with each other transparently, for example having devices on a SWBB wire communicate with devices using the LocalUDP strategy on a LAN. Or wired <-> wireless.
+3. Tunnel packets through another media type by using two extenders mirroring each other. For example, two SWBB buses that are far from each other can be joined transparently through a LAN using the LocalUDP strategy, or through a WAN or Internet using the EthernetTCP strategy. Or join two SWBB local bus segments wirelessly using the OS strategy.
+4. Extend (3) to let packets flow freely between multiple SWBB buses on different media with multiple extenders exchanging the packets on a common media like a LAN with LocalUDP. The buses being connected this way can use a common strategy like SWBB, or different strategies.
+      
+A non-local version of this sketch, connecting two buses with different bus ids, is available as the "Router" sketch among the Network examples.
+Extender examples contributed by Fred Larsen.
+   
+### Extender example
+
+This example implements a device performing the first of the above roles, it simply repeats packets in both directions, allowing a bus to be segmented into multiple media of the same type or of different types.
+Without changes, this example allows examples like local BlinkWithResponse to run on separate SWBB buses on each side of the extender.
+If reaching the maximum length of a wire carrying a SWBB bus, it can be extended with this example.
+It can also be used for connecting multiple media into a single local bus, for example a collection of wired SWBB devices and a collection of wireless devices using the OS strategy.
+
+### Tunneler examples
+
+You can connect multiple extenders in series, with or without devices connected to the buses between the extenders.
+This pair or examples, ExtenderA and ExtenderB, is named Tunneler because without changes it allows a collection of SWBB devices to be connected to another collection of SWBB devices through two extenders connected via a Ethernet LAN using the LocalUDP strategy.
+The SWBB traffic is "tunnelled" through another bus and medium. This corresponds to role 3 in the above list.
+
+By having different device lists in each Extender and connecting multiple of them, we can obtain role 4 in the above list.
+An example is that several collections of SWBB devices are connected together through one extender in each collection, communicating through a LocalUDP bus (Ethernet LAN). In this way, it possible to utilize existing infrastructure instead of pulling new cables or setting up new radio connections.
+
+#### ExtenderA
+
+The device has two buses, a SWBB bus named A and a LocalUDP bus named B. It has a list of devices that belong to the B bus, and will forward packets from bus A to bus B for these devices.
+All packets appearing on bus B that are _not_ sent to these devices, will be forwarded to bus A.
+In this way, all devices on both buses can talk to each other without knowing that the other device is on another bus.
+
+#### ExtenderB
+
+This device is similar to ExtenderA, but has the LocalUDP bus as bus A and a SWBB bus as bus B.
+The list of devices on bus B is the same as in Extender A, meaning that all packets will be forwarded and that there are no devices on the LocalUDP bus connecting the two extenders.
+By changing the device list, the LocalUDP bus (the Ethernet LAN) can also be populated with devices that will be able to communicate with all the other devices.

--- a/examples/Local/Extender/Tunneler/ExtenderA/ExtenderA.ino
+++ b/examples/Local/Extender/Tunneler/ExtenderA/ExtenderA.ino
@@ -1,0 +1,95 @@
+/* This sketch will allow a local bus to be segmented. It can be used for:
+   
+   1. Extending a media like a repeater. For example if SWBB wires are getting too long,
+      it can connect two SWBB wires, extending the range. This can be repeated to enable 
+      really long distances.
+   
+   2. Having devices on different media types communicate with each other transparently,
+      for example having devices on a SWBB wire communicate with devices using the LocalUDP
+      strategy on a LAN. Or wired <-> wireless.
+   
+   3. Tunnel packets through another media type by using two extenders mirroring each other. 
+      For example, two SWBB buses that are far from each other can be joined transparently 
+      through a LAN using the LocalUDP strategy, or through a WAN or Internet using the 
+      EthernetTCP strategy. Or join two SWBB local bus segments wirelessly using the OS strategy.
+
+   4. Extend (3) to let packets flow freely between multiple SWBB buses on different media
+      with multiple extenders exchanging the packets on a common media like a LAN with
+      LocalUDP. The buses being connected this way can use a common strategy like SWBB,
+      or different strategies.
+
+   A non-local version of this sketch, connecting two buses with different bus ids,
+   is available as the "Router" sketch among the Network examples.
+*/
+
+#include <PJON.h>
+
+const uint8_t DEVICE_ID = 50;
+
+// <Strategy name> bus(selected device id)
+PJON<SoftwareBitBang> busA(DEVICE_ID);
+PJON<LocalUDP> busB(DEVICE_ID);
+
+// All packets to devices listed here will be forwarded to bus B
+const uint8_t device_id_ranges_on_B_side[] = {10, 19, 
+                                              80, 89};
+const uint8_t single_device_ids_on_B_side[] = {30, 33, 37, 44, 46};
+
+// Ethernet configuration for this device
+byte gateway[] = { 192, 1, 1, 1 };
+byte subnet[] = { 255, 255, 255, 0 };
+byte mac[] = {0xDE, 0xCD, 0x4E, 0xEF, 0xFE, 0xED};
+byte ip[] = { 192, 1, 1, 185 };
+
+
+void setup() {
+  Serial.begin(115200);
+  Ethernet.begin(mac, ip, gateway, gateway, subnet);
+  
+  busA.strategy.set_pin(7);
+  busA.set_receiver(receiver_functionA);
+  busA.set_router(true);
+  busA.begin();
+  
+  busB.set_receiver(receiver_functionB);
+  busB.set_router(true);
+  busB.begin();
+}
+
+void receiver_functionA(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+  // Forward packet to B segment of local bus
+  if (is_device_on_B_side(packet_info.receiver_id)) {
+    busA.strategy.send_response(PJON_ACK);
+    busB.send_from_id(packet_info.sender_id, packet_info.sender_bus_id, 
+      packet_info.receiver_id, packet_info.receiver_bus_id, payload, length, packet_info.header);
+  }
+}
+
+void receiver_functionB(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+  // Forward packet to A segment of local bus
+  if (!is_device_on_B_side(packet_info.receiver_id)) {
+    busB.strategy.send_response(PJON_ACK);
+    busA.send_from_id(packet_info.sender_id, packet_info.sender_bus_id, 
+      packet_info.receiver_id, packet_info.receiver_bus_id, payload, length, packet_info.header);
+  }
+}
+
+bool is_device_on_B_side(uint8_t device_id) {
+  // Check if in one of the B ranges
+  for (uint8_t i = 0; i < sizeof device_id_ranges_on_B_side - 1; i += 2)
+    if (device_id_ranges_on_B_side[i] <= device_id && device_id <= device_id_ranges_on_B_side[i+1])
+      return true;
+      
+  // Check if one of the individually registered B side devices    
+  for (uint8_t i = 0; i < sizeof single_device_ids_on_B_side; i++) 
+    if (single_device_ids_on_B_side[i] == device_id) return true;
+    
+  return false;  
+}
+
+void loop() {
+  busA.receive(1000);
+  busB.update();
+  busB.receive(1000);
+  busA.update();
+};

--- a/examples/Local/Extender/Tunneler/ExtenderB/ExtenderB.ino
+++ b/examples/Local/Extender/Tunneler/ExtenderB/ExtenderB.ino
@@ -1,0 +1,95 @@
+/* This sketch will allow a local bus to be segmented. It can be used for:
+   
+   1. Extending a media like a repeater. For example if SWBB wires are getting too long,
+      it can connect two SWBB wires, extending the range. This can be repeated to enable 
+      really long distances.
+   
+   2. Having devices on different media types communicate with each other transparently,
+      for example having devices on a SWBB wire communicate with devices using the LocalUDP
+      strategy on a LAN. Or wired <-> wireless.
+   
+   3. Tunnel packets through another media type by using two extenders mirroring each other. 
+      For example, two SWBB buses that are far from each other can be joined transparently 
+      through a LAN using the LocalUDP strategy, or through a WAN or Internet using the 
+      EthernetTCP strategy. Or join two SWBB local bus segments wirelessly using the OS strategy.
+
+   4. Extend (3) to let packets flow freely between multiple SWBB buses on different media
+      with multiple extenders exchanging the packets on a common media like a LAN with
+      LocalUDP. The buses being connected this way can use a common strategy like SWBB,
+      or different strategies.
+
+   A non-local version of this sketch, connecting two buses with different bus ids,
+   is available as the "Router" sketch among the Network examples.
+*/
+
+#include <PJON.h>
+
+const uint8_t DEVICE_ID = 51;
+
+// <Strategy name> bus(selected device id)
+PJON<LocalUDP> busA(DEVICE_ID);
+PJON<SoftwareBitBang> busB(DEVICE_ID);
+
+// All packets to devices listed here will be forwarded to bus B
+const uint8_t device_id_ranges_on_B_side[] = {10, 19, 
+                                              80, 89};
+const uint8_t single_device_ids_on_B_side[] = {30, 33, 37, 44, 46};
+
+// Ethernet configuration for this device
+byte gateway[] = { 192, 1, 1, 1 };
+byte subnet[] = { 255, 255, 255, 0 };
+byte mac[] = {0xEE, 0xCD, 0x4E, 0xEF, 0xFE, 0xED};
+byte ip[] = { 192, 1, 1, 186 };
+
+
+void setup() {
+  Serial.begin(115200);
+  Ethernet.begin(mac, ip, gateway, gateway, subnet);
+  
+  busA.set_receiver(receiver_functionA);
+  busA.set_router(true);
+  busA.begin();
+  
+  busB.strategy.set_pin(7);
+  busB.set_receiver(receiver_functionB);
+  busB.set_router(true);
+  busB.begin();
+}
+
+void receiver_functionA(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+  // Forward packet to B segment of local bus
+  if (is_device_on_B_side(packet_info.receiver_id)) {
+    busA.strategy.send_response(PJON_ACK);
+    busB.send_from_id(packet_info.sender_id, packet_info.sender_bus_id, 
+      packet_info.receiver_id, packet_info.receiver_bus_id, payload, length, packet_info.header);
+  }
+}
+
+void receiver_functionB(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+  // Forward packet to A segment of local bus
+  if (!is_device_on_B_side(packet_info.receiver_id)) {
+    busB.strategy.send_response(PJON_ACK);
+    busA.send_from_id(packet_info.sender_id, packet_info.sender_bus_id, 
+      packet_info.receiver_id, packet_info.receiver_bus_id, payload, length, packet_info.header);
+  }
+}
+
+bool is_device_on_B_side(uint8_t device_id) {
+  // Check if in one of the B ranges
+  for (uint8_t i = 0; i < sizeof device_id_ranges_on_B_side - 1; i += 2)
+    if (device_id_ranges_on_B_side[i] <= device_id && device_id <= device_id_ranges_on_B_side[i+1])
+      return true;
+      
+  // Check if one of the individually registered B side devices    
+  for (uint8_t i = 0; i < sizeof single_device_ids_on_B_side; i++) 
+    if (single_device_ids_on_B_side[i] == device_id) return true;
+    
+  return false;  
+}
+
+void loop() {
+  busA.receive(1000);
+  busB.update();
+  busB.receive(1000);
+  busA.update();
+};


### PR DESCRIPTION
These examples can be used for segmenting a bus into mutiple media, for
example for range extension or spanning wired and wireless with the same
bus.
Also show is a pair of extenders working together to tunnel SWBB traffic
back and forth through an Ethernet LAN using the LocalUDP strategy.