### PR TITLE
Added interface implementation for Windows x86 platform

### DIFF
--- a/interfaces/PJON_Interfaces.h
+++ b/interfaces/PJON_Interfaces.h
@@ -3,3 +3,4 @@
 
 #include "Arduino/PJON_Arduino_Interface.h"
 #include "RPI/PJON_RPI_Interface.h"
+#include "WINX86/PJON_WINX86_Interface.h"

--- a/interfaces/WINX86/PJON_WINX86_Interface.h
+++ b/interfaces/WINX86/PJON_WINX86_Interface.h
@@ -1,0 +1,148 @@
+
+/* PJON Windows x86 Interface
+   _____________________________________________________________________________
+
+    Copyright 2017 Zbigniew Zasieczny z.zasieczny@gmail.com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License. */
+
+#pragma once
+
+#if defined(WINX86)
+  #include <inttypes.h>
+  #include <stdlib.h>
+  #include <string.h>
+
+  #include <chrono>
+  #include <thread>
+  #include <sstream>
+
+  #define OUTPUT 1
+  #define INPUT 0
+  #define HIGH 1
+  #define LOW 0
+  #define INPUT_PULLUP 0x2
+  #define LSBFIRST 1
+  #define MSBFIRST 2
+
+  void pinMode(byte pin, byte m) { ; }
+
+  void digitalWrite(byte, byte) { ; }
+
+  int analogRead(int){
+  return 0;
+  }
+
+  auto start_ts = std::chrono::high_resolution_clock::now();
+
+  uint32_t micros()
+  {
+	  auto elapsed_usec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_ts).count();
+	
+	  if (elapsed_usec >= UINT32_MAX)
+	  {
+		  start_ts = std::chrono::high_resolution_clock::now();
+		  return 0;
+	  } 
+	  else {
+		  return elapsed_usec;
+	  }
+  }
+
+  void delayMicroseconds(uint32_t delay_value)
+  {
+	  auto begin_ts = std::chrono::high_resolution_clock::now();
+
+	  while (true) 
+	  {
+		  auto elapsed_usec = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - begin_ts).count();
+		
+		  if (elapsed_usec >= delay_value) 
+        break;
+
+		  std::this_thread::sleep_for(std::chrono::microseconds(1));
+	  }
+  }
+
+  #ifndef A0
+    #define A0 0
+  #endif
+
+  /* Fallback to WINDOWS-specific functions ------------------------------------ */
+
+  #if !defined(PJON_ANALOG_READ)
+    #define PJON_ANALOG_READ(P) analogRead(P)
+  #endif
+
+  #if !defined(PJON_IO_WRITE)
+    #define PJON_IO_WRITE digitalWrite
+  #endif
+
+  #if !defined(PJON_IO_READ)
+    #define PJON_IO_READ digitalRead
+  #endif
+
+  #if !defined(PJON_IO_MODE)
+    #define PJON_IO_MODE pinMode
+  #endif
+
+  #if !defined(PJON_IO_PULL_DOWN)
+    #define PJON_IO_PULL_DOWN(P) { \
+      PJON_IO_MODE(P, INPUT); \
+      pullUpDnControl(P, PUD_DOWN); \
+    }
+  #endif
+
+
+  /* Random ----------------------------------------------------------------- */
+
+  #ifndef PJON_RANDOM
+    #define PJON_RANDOM(randMax) (int)((1.0 + randMax) * rand() / ( RAND_MAX + 1.0 ) )
+    /* Scale rand()'s return value against RAND_MAX using doubles instead of
+       a pure modulus to have a more distributed result */
+  #endif
+
+  #ifndef PJON_RANDOM_SEED
+    #define PJON_RANDOM_SEED srand
+  #endif
+
+
+  /* Serial ----------------------------------------------------------------- */
+
+  #ifndef PJON_SERIAL_AVAILABLE
+    #define PJON_SERIAL_AVAILABLE(S) S->serialDataAvail()
+  #endif
+
+  #ifndef PJON_SERIAL_WRITE
+    #define PJON_SERIAL_WRITE(S, C) S->putChar((char*)&C)
+  #endif
+
+  #ifndef PJON_SERIAL_READ
+    #define PJON_SERIAL_READ(S) S->getChar()
+  #endif
+
+  #ifndef PJON_SERIAL_FLUSH
+    #define PJON_SERIAL_FLUSH(S) S->flush()
+  #endif
+
+
+  /* Timing ----------------------------------------------------------------- */
+
+  #ifndef PJON_DELAY_MICROSECONDS
+    #define PJON_DELAY_MICROSECONDS delayMicroseconds
+  #endif
+
+  #ifndef PJON_MICROS
+    #define PJON_MICROS micros
+  #endif
+#endif

--- a/interfaces/WINX86/Serial/Serial.cpp
+++ b/interfaces/WINX86/Serial/Serial.cpp
@@ -1,0 +1,177 @@
+/** Serial.cpp
+ *
+ * A very simple serial port control class that does NOT require MFC/AFX.
+ *
+ * @author Hans de Ruiter, Zbigniew Zasieczny
+ *
+ * @version 0.1 -- 28 October 2008
+ * @version 0.2 -- 20 April 2017 (Zbigniew Zasieczny)
+ *  - added methods needed by PJON to handle WINX86 abstraction interface
+ *  - modified flush method to use WIN API
+ *  - added initial tests
+ *  - changed timeouts to 1s
+ */
+
+#include <iostream>
+using namespace std;
+
+#include "Serial.h"
+#include <sstream>
+
+Serial::Serial(tstring &commPortName, int bitRate, bool testOnStartup, bool cycleDtrOnStartup)
+{
+	commHandle = CreateFile(commPortName.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
+		0, NULL);
+
+	if (commHandle == INVALID_HANDLE_VALUE)
+	{
+		throw("ERROR: Could not open com port");
+	}
+	else
+	{
+		// set timeouts
+		COMMTIMEOUTS timeouts;
+
+		/*
+		// blocking
+		timeouts.ReadIntervalTimeout = MAXDWORD;
+		timeouts.ReadTotalTimeoutConstant = 0;
+		timeouts.ReadTotalTimeoutMultiplier = 0;
+		*/
+
+		/*
+		// non-blocking
+		timeouts = { MAXDWORD, 0, 0, 0, 0};
+		*/
+
+		// non-blocking with short timeouts
+		timeouts.ReadIntervalTimeout = 1;
+		timeouts.ReadTotalTimeoutMultiplier = 1;
+		timeouts.ReadTotalTimeoutConstant = 1;
+		timeouts.WriteTotalTimeoutMultiplier = 1;
+		timeouts.WriteTotalTimeoutConstant = 1;
+
+		DCB dcb;
+		if (!SetCommTimeouts(commHandle, &timeouts))
+		{
+			Serial::~Serial();
+			throw("ERROR: Could not set com port time-outs");
+		}
+
+		// set DCB; disabling harware flow control; setting 1N8 mode
+		memset(&dcb, 0, sizeof(dcb));
+		dcb.DCBlength = sizeof(dcb);
+		dcb.BaudRate = bitRate;
+		dcb.fBinary = 1;
+		dcb.fDtrControl = DTR_CONTROL_DISABLE;
+		dcb.fRtsControl = RTS_CONTROL_DISABLE;
+
+		dcb.Parity = NOPARITY;
+		dcb.StopBits = ONESTOPBIT;
+		dcb.ByteSize = 8;
+
+		if (!SetCommState(commHandle, &dcb))
+		{
+			Serial::~Serial();
+			throw("ERROR: Could not set com port parameters");
+		}
+	}
+
+	if (cycleDtrOnStartup) {
+		if (!EscapeCommFunction(commHandle, CLRDTR))
+			throw("ERROR: clearing DTR");
+		Sleep(200);
+		if (!EscapeCommFunction(commHandle, SETDTR))
+			throw("ERROR: setting DTR");
+    }
+
+	if (testOnStartup) {
+		DWORD numWritten;
+		char init[] = "PJON-python init";
+
+		if (!WriteFile(commHandle, init, sizeof(init), &numWritten, NULL))
+			throw("writing initial data to port failed");
+
+		if (numWritten != sizeof(init))
+			throw("ERROR: not all test data written to port");
+	}
+}
+
+Serial::~Serial()
+{
+	CloseHandle(commHandle);
+}
+
+int Serial::write(const char *buffer)
+{
+	DWORD numWritten;
+	WriteFile(commHandle, buffer, strlen(buffer), &numWritten, NULL); 
+
+	return numWritten;
+}
+
+int Serial::write(char *buffer, int buffLen)
+{
+	DWORD numWritten;
+
+	if (!WriteFile(commHandle, buffer, buffLen, &numWritten, NULL))
+		;// printf("serial port write failed\n");
+
+    return numWritten;
+}
+
+int Serial::putChar(char *buffer)
+{
+	return write(buffer, 1);
+}
+
+char Serial::getChar()
+{
+	char buff;
+	read(&buff, 1, false);
+
+	return buff;
+}
+
+int Serial::read(char *buffer, int buffLen, bool nullTerminate)
+{
+	DWORD numRead;
+	if(nullTerminate)
+	{
+		--buffLen;
+	}
+
+	BOOL ret = ReadFile(commHandle, buffer, buffLen, &numRead, NULL);
+
+	if(!ret)
+	{
+		return 0;
+	}
+
+	if(nullTerminate)
+	{
+		buffer[numRead] = '\0';
+	}
+
+	return numRead;
+}
+
+
+bool Serial::serialDataAvail()
+{
+	COMSTAT stats;
+	DWORD error;
+	
+  ClearCommError(commHandle, &error, &stats);
+	
+	if (stats.cbInQue > 0) 
+    return true;
+	
+	return false;
+}
+
+void Serial::flush()
+{
+	PurgeComm(commHandle, PURGE_RXCLEAR | PURGE_TXCLEAR);
+	return;
+}

--- a/interfaces/WINX86/Serial/Serial.h
+++ b/interfaces/WINX86/Serial/Serial.h
@@ -1,0 +1,84 @@
+/** Serial.h
+ *
+ * A very simple serial port control class that does NOT require MFC/AFX.
+ *
+ * License: This source code can be used and/or modified without restrictions.
+ * It is provided as is and the author disclaims all warranties, expressed 
+ * or implied, including, without limitation, the warranties of
+ * merchantability and of fitness for any purpose. The user must assume the
+ * entire risk of using the Software.
+ *
+ * @author Hans de Ruiter, Zbigniew Zasieczny
+ *
+ * @version 0.1 -- 28 October 2008
+ * @version 0.2 -- 20 April 2017 (Zbigniew Zasieczny)
+ *  - added methods needed by PJON to handle WINX86 abstraction interface
+ */
+
+#ifndef __SERIAL_H__
+#define __SERIAL_H__
+
+#include <string>
+#include <windows.h>
+
+typedef std::basic_string<TCHAR> tstring;
+
+class Serial
+{
+private:
+	HANDLE commHandle;
+
+public:
+	Serial(tstring &commPortName, int bitRate = 115200, bool testOnStartup = false, bool cycleDtrOnStartup = false);
+
+	virtual ~Serial();
+
+	/** Writes a NULL terminated string.
+	 *
+	 * @param buffer the string to send
+	 *
+	 * @return int the number of characters written
+	 */
+	int write(const char buffer[]);
+
+	/** Writes a string of bytes to the serial port.
+	 *
+	 * @param buffer pointer to the buffer containing the bytes
+	 * @param buffLen the number of bytes in the buffer
+	 *
+	 * @return int the number of bytes written
+	 */
+	int write(char *buffer, int buffLen);
+
+	/** Reads a string of bytes from the serial port.
+	 *
+	 * @param buffer pointer to the buffer to be written to
+	 * @param buffLen the size of the buffer
+	 * @param nullTerminate if set to true it will null terminate the string
+	 *
+	 * @return int the number of bytes read
+	 */
+	int read(char *buffer, int buffLen, bool nullTerminate = true);
+
+	/** Writes a single character to the serial port
+	*
+	* @param buffer pointer to the buffer to be written to
+	*
+	* @return int the number of bytes written (should be always 1)
+	*/
+	int putChar(char *buffer);
+
+	/** Returns single character from the receive buffer
+	*/
+	char getChar();
+
+	/** Returns true if there is data available in receive buffer
+	*/
+	bool serialDataAvail();
+
+	/** Flushes everything from the serial port's read buffer
+	 */
+	void flush();
+};
+
+#endif

--- a/strategies/ThroughSerial/ThroughSerial.h
+++ b/strategies/ThroughSerial/ThroughSerial.h
@@ -33,6 +33,8 @@ class ThroughSerial {
       int16_t serial = 0;
     #elif defined(ARDUINO)
       Stream *serial = NULL;
+    #elif defined(WINX86)
+      Serial *serial = NULL;
     #endif
     /* Returns the suggested delay related to the attempts passed as parameter: */
 
@@ -150,6 +152,8 @@ class ThroughSerial {
     void set_serial(int16_t serial_port) {
   #elif defined(ARDUINO)
     void set_serial(Stream *serial_port) {
+  #elif defined(WINX86)
+    void set_serial(Serial *serial_port) {
   #endif
       serial = serial_port;
     };


### PR DESCRIPTION
Added interface implementation to make it possible to compile PJON on Windows. 
Only serial port communication is supported (ThroughSerial strategy).

test code: 
Windows test client: https://gist.github.com/Girgitt/a560e3e8f1b1e7561a0162e7ef6fcc36
(it is required to add PJON\interfaces\WINX86\Serial\serial.cpp file to resources in VS 2016 Express otherwise linking will fail)

Arduino test client: https://gist.github.com/Girgitt/f5b1d2d92d3e734f5d94ff38584d2051