### PR TITLE
FIX: uninitialized response causing run time check failure by VS

### DIFF
--- a/PJON.h
+++ b/PJON.h
@@ -1,4 +1,4 @@
-
+﻿
  /*-O//\           __     __
    |-gfo\         |__| | |  | |\ | ™
    |!y°o:\        |  __| |__| | \| v8.2
@@ -496,7 +496,7 @@ class PJON {
     /* Try to receive a packet repeatedly with a maximum duration: */
 
     uint16_t receive(uint32_t duration) {
-      uint16_t response;
+      uint16_t response = PJON_FAIL;
       uint32_t time = PJON_MICROS();
       while((uint32_t)(PJON_MICROS() - time) <= duration) {
         response = receive();


### PR DESCRIPTION
The response in receive function should be initialized otherwise PJON compiled on Windows may fail after couple hours of operation. 