### PR TITLE
Initial LoRa support

### DIFF
--- a/examples/ARDUINO/Local/LoRa/BlinkTest/Receiver/Receiver.ino
+++ b/examples/ARDUINO/Local/LoRa/BlinkTest/Receiver/Receiver.ino
@@ -1,0 +1,33 @@
+#define PJON_INCLUDE_TL
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(44);
+
+void setup() {
+	pinMode(13, OUTPUT);
+	digitalWrite(13, LOW); // Initialize LED 13 to be off
+
+	Serial.begin(9600);
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.begin();
+
+	bus.set_receiver(receiver_function);
+};
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	/* Make use of the payload before sending something, the buffer where payload points to is
+	   overwritten when a new message is dispatched */
+	if (payload[0] == 'B') {
+		digitalWrite(13, HIGH);
+		delay(30);
+		digitalWrite(13, LOW);
+	}
+};
+
+void loop() {
+	bus.receive(1000);
+};

--- a/examples/ARDUINO/Local/LoRa/BlinkTest/Transmitter/Transmitter.ino
+++ b/examples/ARDUINO/Local/LoRa/BlinkTest/Transmitter/Transmitter.ino
@@ -1,0 +1,19 @@
+#define PJON_INCLUDE_TL
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(45);
+
+void setup() {
+	Serial.begin(9600);
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.begin();
+	bus.send_repeatedly(44, "B", 1, 1000000); // Send B to device 44 every second
+};
+
+void loop() {
+	bus.update();
+};

--- a/examples/ARDUINO/Local/LoRa/HalfDuplex/Device1/Device1.ino
+++ b/examples/ARDUINO/Local/LoRa/HalfDuplex/Device1/Device1.ino
@@ -1,0 +1,58 @@
+#define PJON_INCLUDE_TL
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(44);
+
+void setup() {
+	pinMode(13, OUTPUT);
+	digitalWrite(13, LOW); // Initialize LED 13 to be off
+
+	bus.set_receiver(receiver_function);
+	bus.set_error(error_handler);
+
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+
+	bus.begin();
+
+	bus.send(45, "B", 1);
+
+	Serial.begin(115200);
+};
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	/* Make use of the payload before sending something, the buffer where payload points to is
+	   overwritten when a new message is dispatched */
+	if ((char)payload[0] == 'B') {
+		bus.reply("B", 1);
+		digitalWrite(13, HIGH);
+		delay(5);
+		digitalWrite(13, LOW);
+	}
+}
+
+void error_handler(uint8_t code, uint8_t data) {
+	if (code == PJON_CONNECTION_LOST) {
+		Serial.print("Connection with device ID ");
+		Serial.print(bus.packets[data].content[0], DEC);
+		Serial.println(" is lost.");
+	}
+	if (code == PJON_PACKETS_BUFFER_FULL) {
+		Serial.print("Packet buffer is full, has now a length of ");
+		Serial.println(data, DEC);
+		Serial.println("Possible wrong bus configuration!");
+		Serial.println("higher PJON_MAX_PACKETS if necessary.");
+	}
+	if (code == PJON_CONTENT_TOO_LONG) {
+		Serial.print("Content is too long, length: ");
+		Serial.println(data);
+	}
+};
+
+void loop() {
+	bus.receive(20000);
+	bus.update();
+};

--- a/examples/ARDUINO/Local/LoRa/HalfDuplex/Device2/Device2.ino
+++ b/examples/ARDUINO/Local/LoRa/HalfDuplex/Device2/Device2.ino
@@ -1,0 +1,58 @@
+#define PJON_INCLUDE_TL
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(45);
+
+void setup() {
+	pinMode(13, OUTPUT);
+	digitalWrite(13, LOW); // Initialize LED 13 to be off
+	bus.set_error(error_handler);
+
+	bus.set_receiver(receiver_function);
+
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+
+	bus.begin();
+
+	bus.send(44, "B", 1);
+
+	Serial.begin(115200);
+};
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	/* Make use of the payload before sending something, the buffer where payload points to is
+	   overwritten when a new message is dispatched */
+	if ((char)payload[0] == 'B') {
+		bus.reply("B", 1);
+		digitalWrite(13, HIGH);
+		delay(5);
+		digitalWrite(13, LOW);
+	}
+}
+
+void error_handler(uint8_t code, uint8_t data) {
+	if (code == PJON_CONNECTION_LOST) {
+		Serial.print("Connection with device ID ");
+		Serial.print(bus.packets[data].content[0], DEC);
+		Serial.println(" is lost.");
+	}
+	if (code == PJON_PACKETS_BUFFER_FULL) {
+		Serial.print("Packet buffer is full, has now a length of ");
+		Serial.println(data, DEC);
+		Serial.println("Possible wrong bus configuration!");
+		Serial.println("higher PJON_MAX_PACKETS if necessary.");
+	}
+	if (code == PJON_CONTENT_TOO_LONG) {
+		Serial.print("Content is too long, length: ");
+		Serial.println(data);
+	}
+};
+
+void loop() {
+	bus.receive(20000);
+	bus.update();
+};

--- a/examples/ARDUINO/Local/LoRa/HalfDuplexNoAcknowledge/Device1/Device1.ino
+++ b/examples/ARDUINO/Local/LoRa/HalfDuplexNoAcknowledge/Device1/Device1.ino
@@ -1,0 +1,39 @@
+#define PJON_INCLUDE_TL
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(44);
+
+void setup() {
+	pinMode(13, OUTPUT);
+	digitalWrite(13, LOW); // Initialize LED 13 to be off
+
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.set_synchronous_acknowledge(false);
+	bus.set_receiver(receiver_function);
+
+	bus.begin();
+
+	bus.send_repeatedly(45, "B", 1, 1000000);
+
+	Serial.begin(115200);
+};
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	/* Make use of the payload before sending something, the buffer where payload points to is
+	   overwritten when a new message is dispatched */
+	if ((char)payload[0] == 'B') {
+		digitalWrite(13, HIGH);
+		delay(5);
+		digitalWrite(13, LOW);
+		delay(5);
+	}
+}
+
+void loop() {
+	bus.receive();
+	bus.update();
+};

--- a/examples/ARDUINO/Local/LoRa/HalfDuplexNoAcknowledge/Device2/Device2.ino
+++ b/examples/ARDUINO/Local/LoRa/HalfDuplexNoAcknowledge/Device2/Device2.ino
@@ -1,0 +1,39 @@
+#define PJON_INCLUDE_TL
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(45);
+
+void setup() {
+	pinMode(13, OUTPUT);
+	digitalWrite(13, LOW); // Initialize LED 13 to be off
+
+	bus.set_synchronous_acknowledge(false);
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.set_receiver(receiver_function);
+
+	bus.begin();
+
+	bus.send_repeatedly(44, "B", 1, 1000000);
+
+	Serial.begin(115200);
+};
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	/* Make use of the payload before sending something, the buffer where payload points to is
+	   overwritten when a new message is dispatched */
+	if ((char)payload[0] == 'B') {
+		digitalWrite(13, HIGH);
+		delay(5);
+		digitalWrite(13, LOW);
+		delay(5);
+	}
+};
+
+void loop() {
+	bus.receive();
+	bus.update();
+};

--- a/examples/ARDUINO/Local/LoRa/JSON/Receiver/Receiver.ino
+++ b/examples/ARDUINO/Local/LoRa/JSON/Receiver/Receiver.ino
@@ -1,0 +1,36 @@
+#define PJON_INCLUDE_TL
+#include <SPI.h>
+#include <PJON.h>
+#include <ArduinoJson.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+and JSON library from https://github.com/bblanchon/ArduinoJson
+*/
+PJON<ThroughLora> LoraPJON(44);
+
+void setup() {
+	Serial.begin(115200);
+	Serial.println("LoRa Receiver");
+
+	LoraPJON.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	LoraPJON.strategy.setSignalBandwidth(250E3); //Optional
+
+	LoraPJON.begin();
+	//LoraPJON.set_communication_mode(PJON_SIMPLEX); //Optional disable ACK
+	LoraPJON.set_receiver(receiver_function);
+}
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	//Serial.println((float)pow(10.0, (-45.0 - (float)LoRa.packetRssi()) / 20.0)); Aproximate distance
+	DynamicJsonBuffer  jsonBuffer(200);
+	JsonObject& root = jsonBuffer.parseObject((char *)payload);
+	root["RSSI"] = LoraPJON.strategy.packetRssi();
+	root["SNR"] = LoraPJON.strategy.packetSnr();
+	root.printTo(Serial);
+	Serial.println();
+};
+
+void loop() {
+	LoraPJON.update();
+	LoraPJON.receive();
+}

--- a/examples/ARDUINO/Local/LoRa/JSON/Transmitter/Transmitter.ino
+++ b/examples/ARDUINO/Local/LoRa/JSON/Transmitter/Transmitter.ino
@@ -1,0 +1,53 @@
+#define PJON_INCLUDE_TL
+#include <SPI.h>
+#include <LoRa.h>
+#include <PJON.h>
+#include <ArduinoJson.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+and JSON library from https://github.com/bblanchon/ArduinoJson
+*/
+#define EVENT_TIME	1000 //1 message every 1 second
+
+PJON<ThroughLora> LoraPJON(45);
+
+void setup() {
+	Serial.begin(115200);
+	Serial.println("LoRa Transmitter");
+
+	LoraPJON.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	LoraPJON.strategy.setSignalBandwidth(250E3); //Optional
+
+	LoraPJON.begin();
+	//LoraPJON.set_communication_mode(PJON_SIMPLEX); //Optional disable ACK
+}
+
+void loop() {
+	LoraPJON.update();
+	LoraPJON.receive();
+	eventManager(); //Send a message every 1 second without using PJON auto repeat
+}
+
+inline void eventManager() {
+	static uint32_t lastTime = millis();
+	if (millis() - lastTime > EVENT_TIME) {
+		generateData();
+		lastTime = millis();
+	}
+}
+
+inline void generateData() {
+	String message;
+	DynamicJsonBuffer  jsonBuffer(200);
+	JsonObject& root = jsonBuffer.createObject();
+	JsonArray& data = root.createNestedArray("ADC");
+	data.add(analogRead(A0));
+	data.add(analogRead(A1));
+	data.add(analogRead(A2));
+	data.add(analogRead(A3));
+	data.add(analogRead(A4));
+	data.add(analogRead(A5));
+	root.printTo(message);
+
+	LoraPJON.send(44, message.c_str(), message.length());
+}

--- a/examples/ARDUINO/Local/LoRa/NetworkAnalysis/Receiver/Receiver.ino
+++ b/examples/ARDUINO/Local/LoRa/NetworkAnalysis/Receiver/Receiver.ino
@@ -1,0 +1,29 @@
+#define PJON_INCLUDE_TL
+// Uncomment to run SoftwareBitBang to mode FAST
+// #define SWBB_MODE 2
+// Uncomment to run SoftwareBitBang to mode OVERDRIVE
+// #define SWBB_MODE 3
+
+/*  Acknowledge Latency maximum duration (1000 microseconds default).
+	Can be necessary to higher SWBB_RESPONSE_TIMEOUT to leave enough time to
+	receiver to compute the CRC and to respond with a synchronous acknowledgement
+	SWBB_RESPONSE_TIMEOUT can be reduced to higher communication speed if
+	devices are near and able to compute CRC fast enough. */
+	//#define SWBB_RESPONSE_TIMEOUT 1000
+
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(44);
+
+void setup() {
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.begin();
+};
+
+void loop() {
+	bus.receive();
+};

--- a/examples/ARDUINO/Local/LoRa/NetworkAnalysis/Transmitter/Transmitter.ino
+++ b/examples/ARDUINO/Local/LoRa/NetworkAnalysis/Transmitter/Transmitter.ino
@@ -1,0 +1,99 @@
+#define PJON_INCLUDE_TL
+// Uncomment to run SoftwareBitBang to mode FAST
+// #define SWBB_MODE 2
+// Uncomment to run SoftwareBitBang to mode OVERDRIVE
+// #define SWBB_MODE 3
+
+/*  Acknowledge Latency maximum duration (1000 microseconds default).
+	Can be necessary to higher SWBB_RESPONSE_TIMEOUT to leave enough time to
+	receiver to compute the CRC and to respond with a synchronous acknowledgement
+	SWBB_RESPONSE_TIMEOUT can be reduced to higher communication speed if
+	devices are near and able to compute CRC fast enough. */
+	//#define SWBB_RESPONSE_TIMEOUT 1000
+
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+float test;
+float mistakes;
+int busy;
+int fail;
+
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(45);
+
+int packet;
+char content[] = "01234567890123456789";
+
+void setup() {
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.set_error(error_handler);
+	bus.begin();
+
+	Serial.begin(115200);
+	Serial.println("PJON - Network analysis");
+	Serial.println("Starting a 5 second communication test...");
+	Serial.println();
+}
+
+void error_handler(uint8_t code, uint8_t data) {
+	if (code == PJON_CONNECTION_LOST) {
+		Serial.print("Connection with device ID ");
+		Serial.print(data);
+		Serial.println(" is lost.");
+	}
+	if (code == PJON_PACKETS_BUFFER_FULL) {
+		Serial.print("Packet buffer is full, has now a length of ");
+		Serial.println(bus.packets[data].content[0], DEC);
+		Serial.println("Possible wrong bus configuration!");
+		Serial.println("higher PJON_MAX_PACKETS if necessary.");
+	}
+	if (code == PJON_CONTENT_TOO_LONG) {
+		Serial.print("Content is too long, length: ");
+		Serial.println(data);
+	}
+};
+
+void loop() {
+	long time = millis();
+	while (millis() - time < 5000) {
+		/* Here send_packet low level function is used to
+		be able to catch every single sending result. */
+
+		unsigned int response = bus.send_packet(44, content, 20);
+		if (response == PJON_ACK)
+			test++;
+		if (response == PJON_NAK)
+			mistakes++;
+		if (response == PJON_BUSY)
+			busy++;
+		if (response == PJON_FAIL)
+			fail++;
+	}
+
+	Serial.print("Absolute com speed: ");
+	Serial.print((test * 26.0) / 5.0);
+	Serial.println("B/s");
+	Serial.print("Practical bandwidth: ");
+	Serial.print((test * 20.0) / 5.0);
+	Serial.println("B/s");
+	Serial.print("Packets sent: ");
+	Serial.println(test);
+	Serial.print("Mistakes (error found with CRC) ");
+	Serial.println(mistakes);
+	Serial.print("Fail (no answer from receiver) ");
+	Serial.println(fail);
+	Serial.print("Busy (Channel is busy or affected by interference) ");
+	Serial.println(busy);
+	Serial.print("Accuracy: ");
+	Serial.print(100 - (100 / (test / mistakes)));
+	Serial.println(" %");
+	Serial.println(" --------------------- ");
+
+	test = 0;
+	mistakes = 0;
+	busy = 0;
+	fail = 0;
+};

--- a/examples/ARDUINO/Local/LoRa/Simplex/Receiver/Receiver.ino
+++ b/examples/ARDUINO/Local/LoRa/Simplex/Receiver/Receiver.ino
@@ -1,0 +1,74 @@
+#define PJON_INCLUDE_TL
+#define OS_GAIN_REFRESH_DELAY 0
+/* Gain refresh time of SRX882 module is around 100 milliseconds.
+   If only one pair of SRX and STX are used to connect 2 devices in SIMPLEX
+   mode, there is no need to refresh receiver's gain, being communication
+   mono-directional. */
+
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+float test;
+float mistakes;
+int busy;
+int fail;
+
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(44);
+
+void setup() {
+	bus.set_communication_mode(PJON_SIMPLEX);
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+	bus.begin();
+
+	bus.set_receiver(receiver_function);
+
+	Serial.begin(115200);
+};
+
+void receiver_function(uint8_t *payload, uint16_t length, const PJON_Packet_Info &packet_info) {
+	// Do nothing to avoid affecting speed analysis
+}
+
+void loop() {
+	Serial.println("Starting 1 second communication speed test...");
+	long time = millis();
+	unsigned int response = 0;
+	while (millis() - time < 1000) {
+		response = bus.receive();
+		if (response == PJON_ACK)
+			test++;
+		if (response == PJON_NAK)
+			mistakes++;
+		if (response == PJON_BUSY)
+			busy++;
+		if (response == PJON_FAIL)
+			fail++;
+	}
+
+	Serial.print("Absolute com speed: ");
+	Serial.print(test * 25);
+	Serial.println("B/s");
+	Serial.print("Practical bandwidth: ");
+	Serial.print(test * 20);
+	Serial.println("B/s");
+	Serial.print("Packets sent: ");
+	Serial.println(test);
+	Serial.print("Mistakes (error found with CRC) ");
+	Serial.println(mistakes);
+	Serial.print("Fail (no answer from receiver) ");
+	Serial.println(fail);
+	Serial.print("Busy (Channel is busy or affected by interference) ");
+	Serial.println(busy);
+	Serial.print("Accuracy: ");
+	Serial.print(100 - (100 / (test / mistakes)));
+	Serial.println(" %");
+	Serial.println(" --------------------- ");
+
+	test = 0;
+	mistakes = 0;
+	busy = 0;
+	fail = 0;
+};

--- a/examples/ARDUINO/Local/LoRa/Simplex/Transmitter/Transmitter.ino
+++ b/examples/ARDUINO/Local/LoRa/Simplex/Transmitter/Transmitter.ino
@@ -1,0 +1,42 @@
+#define PJON_INCLUDE_TL
+#define OS_GAIN_REFRESH_DELAY 0
+/* Gain refresh time of SRX882 module is around 100 milliseconds.
+   If only one pair of SRX and STX are used to connect 2 devices in SIMPLEX
+   mode, there is no need to refresh receiver's gain, being communication
+   mono-directional. */
+
+#include <PJON.h>
+/*
+To use this example, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+float test;
+float mistakes;
+int busy;
+int fail;
+
+// <Strategy name> bus(selected device id)
+PJON<ThroughLora> bus(45);
+
+int packet;
+char content[] = "01234567890123456789";
+
+void setup() {
+	bus.set_communication_mode(PJON_SIMPLEX);
+	bus.strategy.setFrequency(868100000UL); //Obrigatory to initialize Radio with correct frequency
+	bus.strategy.setSignalBandwidth(250E3); //Optional
+
+	bus.begin();
+	packet = bus.send(44, content, 20);
+
+	Serial.begin(115200);
+	Serial.println("PJON - Network analysis");
+	Serial.println("Starting a 1 second communication test..");
+	Serial.println();
+}
+
+void loop() {
+	bus.update();
+
+	if (!bus.packets[packet].state)
+		packet = bus.send(44, content, 20);
+};

--- a/strategies/LoRa/ThroughLora.h
+++ b/strategies/LoRa/ThroughLora.h
@@ -1,0 +1,186 @@
+
+/* ThroughSerial digital communication data link layer
+   used as a Strategy by the PJON framework (included in version v4.1)
+
+   Contributors:
+    - Fred Larsen, Development, testing and debugging
+    - Zbigniew Zasieczny, collision avoidance multi-drop RS485 (latency)
+      and SoftwareSerial compatibility
+    - Franketto (Arduino forum user) RS485 TX enable pin compatibility
+    - Endre Karlson separate RS485 enable pins handling, flush timing hack
+   ____________________________________________________________________________
+
+   ThroughSerial, copyright 2016-2017 by Giovanni Blu Mitolo All rights reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/*
+To use this strategy, please download the LoRa third party Library from https://github.com/sandeepmistry/arduino-LoRa/
+*/
+
+#pragma once
+
+#include <LoRa.h>
+#include "Timing.h"
+
+class ThroughLora {
+  public:
+    /* Returns the suggested delay related to the attempts passed as parameter: */
+
+    uint32_t back_off(uint8_t attempts) {
+      uint32_t result = attempts;
+      for(uint8_t d = 0; d < TS_BACK_OFF_DEGREE; d++)
+        result *= (uint32_t)(attempts);
+      return result;
+    };
+
+    /* Begin method, to be called before transmission or reception:
+       (returns always true) */
+
+	int packetRssi() {
+		return LoRa.packetRssi();
+	}
+
+	float packetSnr() {
+		return LoRa.packetSnr();
+	}
+
+	bool setFrequency(uint32_t frequency) {
+		return LoRa.begin(frequency);
+	}
+
+	bool setSignalBandwidth(uint32_t bandwidth) {
+		LoRa.setSignalBandwidth(bandwidth);
+		return true;
+	}
+
+	bool setPins(uint8_t cs_pin, uint8_t reset_pin, uint8_t dio0_pin) {
+		LoRa.setPins(cs_pin, reset_pin, dio0_pin);
+		return true;
+	}
+
+
+    bool begin(uint8_t additional_randomness = 0) {
+      PJON_DELAY_MICROSECONDS(
+        PJON_RANDOM(TS_INITIAL_DELAY) + additional_randomness
+      );
+ 
+      return true;
+    };
+
+
+    /* Check if the channel is free for transmission: */
+
+    bool can_start() {
+      //PJON_DELAY_MICROSECONDS(PJON_RANDOM(TS_COLLISION_DELAY));
+	  if (LoRa.parsePacket() > 0) return false;
+      if((uint32_t)(PJON_MICROS() - _last_reception_time) < TS_TIME_IN)
+        return false;
+      return true;
+    };
+
+
+    /* Returns the maximum number of attempts for each transmission: */
+
+    static uint8_t get_max_attempts() {
+      return TS_MAX_ATTEMPTS;
+    };
+
+
+    /* Handle a collision: */
+
+    void handle_collision() {
+      PJON_DELAY_MICROSECONDS(PJON_RANDOM(TS_COLLISION_DELAY));
+    };
+
+
+
+    /* Receive byte response */
+
+    uint16_t receive_response() {
+		//LoRa.receive();
+		uint32_t time = PJON_MICROS();
+		
+		while ((uint32_t)(PJON_MICROS() - time) < TS_RESPONSE_TIME_OUT) {
+			uint8_t frame_size = LoRa.parsePacket();
+
+			if (frame_size > 0) {
+			
+				return LoRa.read();
+			}
+		}
+		return PJON_FAIL;
+    };
+
+
+    /* Receive a string: */
+
+	uint16_t receive_string(uint8_t *string, uint16_t max_length) {
+		uint8_t frameSize = LoRa.parsePacket();
+		if (frameSize > 0) {
+			while (LoRa.available()) {
+				*string = LoRa.read();
+				string++;
+			}
+			return frameSize;
+		}
+		else {
+			return PJON_FAIL;
+		}
+    };
+
+
+    /* Send a byte and wait for its transmission end */
+
+    void send_byte(uint8_t b) {
+      LoRa.write(b);
+    };
+
+
+    /* Send byte response to the packet's transmitter */
+
+    void send_response(uint8_t response) {
+		
+		start_tx();
+		send_byte(response);
+		end_tx();
+    };
+
+
+    /* Send a string: */
+
+    void send_string(uint8_t *string, uint8_t length) {
+      start_tx();
+      for(uint8_t b = 0; b < length; b++) {
+        send_byte(string[b]);
+      }
+      end_tx();
+    };
+
+
+    /* Pass the Serial port where you want to operate with */
+
+    /* RS485 enable pins handling: */
+
+    void start_tx() {
+      LoRa.beginPacket();
+    };
+
+    void end_tx() {
+		LoRa.endPacket();
+    };
+
+
+  private:
+    uint32_t _last_reception_time;
+};

--- a/strategies/LoRa/Timing.h
+++ b/strategies/LoRa/Timing.h
@@ -1,0 +1,66 @@
+/* ThroughSerial digital communication data link layer
+   used as a Strategy by the PJON framework (included in version v4.1)
+
+   Contributors:
+    - Fred Larsen, Development, testing and debugging
+    - Zbigniew Zasieczny, collision avoidance multi-drop RS485 (latency)
+      and SoftwareSerial compatibility
+    - Franketto (Arduino forum user) RS485 TX enable pin compatibility
+   ____________________________________________________________________________
+
+   ThroughSerial, Copyright (c) 2016 by Giovanni Blu Mitolo All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+/* Maximum 1 second random initial delay */
+#ifndef TS_INITIAL_DELAY
+  #define TS_INITIAL_DELAY      1000
+#endif
+
+/* Mamimum 32 microseconds random delay in case of collision */
+#ifndef TS_COLLISION_DELAY
+  #define TS_COLLISION_DELAY      32
+#endif
+
+/* Set 100 milliseconds as the maximum timeframe between transmission and
+   synchronous acknowledgement response. This value is strictly related to the
+   maximum time needed by receiver to receive, compute and transmit a response.
+   Higher if necessary. */
+
+  #define TS_RESPONSE_TIME_OUT 100000UL
+
+
+/* Minum timeframe with channel free for use before transmission.
+   (Avoid disrupting synchronous acknowledgement exchange) */
+#ifndef TS_TIME_IN
+  #define TS_TIME_IN  TS_RESPONSE_TIME_OUT + TS_COLLISION_DELAY
+#endif
+
+/* Set 5 milliseconds as the maximum timeframe for byte reception.
+   This value depends on the latency, baud rate and computation time.
+   Always set TS_BYTE_TIME_OUT > (byte transmission time + latency) */
+#ifndef TS_BYTE_TIME_OUT
+  #define TS_BYTE_TIME_OUT      5000
+#endif
+
+/* Maximum transmission attempts */
+#ifndef TS_MAX_ATTEMPTS
+  #define TS_MAX_ATTEMPTS         10
+#endif
+
+/* Back-off exponential degree */
+#ifndef TS_BACK_OFF_DEGREE
+  #define TS_BACK_OFF_DEGREE       3
+#endif

--- a/strategies/PJON_Strategies.h
+++ b/strategies/PJON_Strategies.h
@@ -40,6 +40,9 @@
 #if defined(PJON_INCLUDE_TS)
   #include "ThroughSerial/ThroughSerial.h"
 #endif
+#if defined(PJON_INCLUDE_TL)
+  #include "LoRa/ThroughLora.h"
+#endif
 #if defined(PJON_INCLUDE_NONE)
   /* None for custom strategy inclusion */
 #endif


### PR DESCRIPTION
To enable LoRa strategy "#define PJON_INCLUDE_TL" must be added in the
sketch.

About the frame separation. From what i understool, there's an internal frame buffer in lora hardware of 255 bytes, then the library polls this data from the fifo (or via interrupt) to arduino buffer. So the interface with PJON just polls data from the lora library buffer, so we have 2 buffers in total. One from PJON, and another from LoRa library. 
It would be more efficient maybe if it was possible to pass the LoRa buffer as PJON buffer, but it would imply changes to the lora library.