### PR TITLE
Port support in Surrogate sketch

### DIFF
--- a/examples/ARDUINO/Local/EthernetTCP/SoftwareBitBangSurrogate/Surrogate/Surrogate.ino
+++ b/examples/ARDUINO/Local/EthernetTCP/SoftwareBitBangSurrogate/Surrogate/Surrogate.ino
@@ -62,7 +62,8 @@ void receiver_functionA(uint8_t *payload, uint16_t length, const PJON_Packet_Inf
     busB.localhost,
     (char *)payload,
     length,
-    packet_info.header
+    packet_info.header,
+    packet_info.port
   );
 }
 
@@ -75,7 +76,8 @@ void receiver_functionB(uint8_t *payload, uint16_t length, const PJON_Packet_Inf
     packet_info.receiver_bus_id,
     (char *)payload,
     length,
-    packet_info.header
+    packet_info.header,
+    packet_info.port
   );  
 }
 


### PR DESCRIPTION
The surrogate can now support a RemoteWorker/master on for example a
Linux machine, using a higher level protocol with a dedicated port.