### PR TITLE
Make LUDP_RESPONSE_TIMEOUT overridable in strategy

### DIFF
--- a/src/strategies/LocalUDP/LocalUDP.h
+++ b/src/strategies/LocalUDP/LocalUDP.h
@@ -28,9 +28,11 @@
 
 #include <PJONDefines.h>
 
-#define LUDP_DEFAULT_PORT                 7100
-#define LUDP_RESPONSE_TIMEOUT  (uint32_t) 100000
-#define LUDP_MAGIC_HEADER      (uint32_t) 0x0DFAC3D0
+#define LUDP_DEFAULT_PORT                   7100
+#ifndef LUDP_RESPONSE_TIMEOUT
+  #define LUDP_RESPONSE_TIMEOUT  (uint32_t) 100000
+#endif
+#define LUDP_MAGIC_HEADER        (uint32_t) 0x0DFAC3D0
 
 class LocalUDP {
     bool _udp_initialized = false;


### PR DESCRIPTION
We should change LUDP_RESPONSE_TIMEOUT to be overridable in the strategy. See also:
* https://github.com/gioblu/PJON/issues/222#issuecomment-410445654
* TS_RESPONSE_TIME_OUT

(we should also use a consistent naming; either TIMEOUT or TIME_OUT - not both)