### PR TITLE
Adds support for STM32-duino installed via the board.json

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=PJON is an open-source, multi-master, multi-media bus network protocol
 paragraph=It is a valid alternative to i2c, 1-Wire, CAN and other protocols
 category=Communication
 url=https://github.com/gioblu/PJON
-architectures=atmelavr,avr,esp8266,esp32,sam,samd,teensy,tiny,stm32
+architectures=atmelavr,avr,esp8266,esp32,sam,samd,teensy,tiny,stm32,STM32F1


### PR DESCRIPTION
When installing STM32duino using the instructions from http://wiki.stm32duino.com/index.php?title=Boards_Manager_package it installs the platform STM32F1 instead of stm32.

The one from github still used stm32 https://github.com/stm32duino/wiki/wiki/Getting-Started.