### PR TITLE
STM32 Workarround for missing ethernet refernces

### DIFF
--- a/src/strategies/PJON_Strategies.h
+++ b/src/strategies/PJON_Strategies.h
@@ -76,9 +76,9 @@
   #include "SoftwareBitBang/SoftwareBitBang.h"
   #include "ThroughSerial/ThroughSerial.h"
   #include "ThroughSerialAsync/ThroughSerialAsync.h"
-  /* Avoid ATtiny44/84/45/85 missing inclusion error */
+  /* Avoid ATtiny44/84/45/85 and STM32F1 missing inclusion error */
   #if !defined(__AVR_ATtiny45__) && !defined(__AVR_ATtiny85__) && \
-      !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny84__)
+      !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny84__) && !defined(STM32F1xx)
     #include "EthernetTCP/EthernetTCP.h"
     #include "LocalUDP/LocalUDP.h"
     #include "GlobalUDP/GlobalUDP.h"

--- a/src/strategies/PJON_Strategies.h
+++ b/src/strategies/PJON_Strategies.h
@@ -78,7 +78,7 @@
   #include "ThroughSerialAsync/ThroughSerialAsync.h"
   /* Avoid ATtiny44/84/45/85 and STM32F1 missing inclusion error */
   #if !defined(__AVR_ATtiny45__) && !defined(__AVR_ATtiny85__) && \
-      !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny84__) && !defined(STM32F1xx)
+      !defined(__AVR_ATtiny44__) && !defined(__AVR_ATtiny84__) && !defined(ARDUINO_ARCH_STM32)
     #include "EthernetTCP/EthernetTCP.h"
     #include "LocalUDP/LocalUDP.h"
     #include "GlobalUDP/GlobalUDP.h"


### PR DESCRIPTION
Excludes Ethernet from default strategies because of missing references (like ATtiny85).

Workaround so the examples compile at least until STM32 Ethernet gets fixed.

This only excludes STM32F1.