### PR TITLE
ESP-NOW strategy support for esp8266

### DIFF
--- a/src/PJON.h
+++ b/src/PJON.h
@@ -563,8 +563,7 @@ class PJON {
         !(payload[1] & PJON_ACK_REQ_BIT) ||
         _mode == PJON_SIMPLEX
       ) return PJON_ACK;
-      //return (strategy.receive_response() == PJON_ACK) ? PJON_ACK : PJON_FAIL;
-      return PJON_ACK;
+      return (strategy.receive_response() == PJON_ACK) ? PJON_ACK : PJON_FAIL;
     };
 
     /* Compose and transmit a packet passing its info as parameters: */

--- a/src/PJON.h
+++ b/src/PJON.h
@@ -563,7 +563,8 @@ class PJON {
         !(payload[1] & PJON_ACK_REQ_BIT) ||
         _mode == PJON_SIMPLEX
       ) return PJON_ACK;
-      return (strategy.receive_response() == PJON_ACK) ? PJON_ACK : PJON_FAIL;
+      //return (strategy.receive_response() == PJON_ACK) ? PJON_ACK : PJON_FAIL;
+      return PJON_ACK;
     };
 
     /* Compose and transmit a packet passing its info as parameters: */

--- a/src/interfaces/ARDUINO/ESPNOWHelper.h
+++ b/src/interfaces/ARDUINO/ESPNOWHelper.h
@@ -18,9 +18,10 @@
 	#include <esp_now.h>
 #endif
 
-#if CONFIG_STATION_MODE // ESPNOW can work in both station and softap mode. It is configured in menuconfig.
+#if defined(CONFIG_STATION_MODE) // ESPNOW can work in both station and softap mode. It is configured in menuconfig.
 	#if defined(ESP8266)
-		#define ESPNOW_WIFI_MODE ESP_NOW_ROLE_CONTROLLER
+		#define ESPNOW_WIFI_MODE WIFI_STA
+        #define ESPNOW_WIFI_ROLE ESP_NOW_ROLE_CONTROLLER
 	#elif defined(ESP32)
 		#define ESPNOW_WIFI_MODE WIFI_MODE_STA
 		#define ESPNOW_WIFI_IF ESP_IF_WIFI_STA
@@ -28,7 +29,8 @@
  
 #else
 	#if defined(ESP8266)
-		#define ESPNOW_WIFI_MODE ESP_NOW_ROLE_COMBO
+		#define ESPNOW_WIFI_MODE WIFI_AP
+        #define ESPNOW_WIFI_ROLE ESP_NOW_ROLE_COMBO
 	#elif defined(ESP32)
 		#define ESPNOW_WIFI_MODE WIFI_MODE_AP
 		#define ESPNOW_WIFI_IF ESP_IF_WIFI_AP
@@ -52,20 +54,13 @@ enum {
 static uint8_t last_mac[ESP_NOW_ETH_ALEN];
 static PacketQueue packetQueue;
 volatile bool sendingDone = true;
-volatile uint32_t sendCount = 0;
-volatile uint32_t recCalled = 0;
-volatile uint32_t failCount = 0;
 
 static void espnow_send_cb(const uint8_t *mac_addr, uint8_t status) {
-	sendCount++;
-	if (status != 0)
-		failCount++;
 	// The only thing we do in the send callback is unblock the other thread which blocks after posting data to the MAC
 	sendingDone = true; 
 };
 
 static void espnow_recv_cb(const uint8_t *mac_addr, const uint8_t *data, int len) {
-	recCalled++;
 	espnow_packet_t* packet = new espnow_packet_t();
 
 	memcpy(packet->mac_addr, mac_addr, ESP_NOW_ETH_ALEN);
@@ -75,7 +70,6 @@ static void espnow_recv_cb(const uint8_t *mac_addr, const uint8_t *data, int len
 	packet->data_len = len;
 
 	if (!packetQueue.push(packet)) { // queue is full - drop the packet
-		failCount++;
 		free(packet->data);
 		delete packet;
 	}
@@ -126,19 +120,24 @@ public:
 		memcpy(_esp_pmk, espnow_pmk, 16);
 
 		#ifdef ESP8266
-			WiFi.channel(_channel);
+            WiFi.mode(ESPNOW_WIFI_MODE);
+			wifi_set_channel(_channel);
 			esp_now_init();
-			esp_now_set_self_role(ESPNOW_WIFI_MODE);
+			esp_now_set_self_role(ESPNOW_WIFI_ROLE);
 			esp_now_register_send_cb(reinterpret_cast<esp_now_send_cb_t>(espnow_send_cb));
 			esp_now_register_recv_cb(reinterpret_cast<esp_now_recv_cb_t>(espnow_recv_cb));
 		#else
 			tcpip_adapter_init();
 			wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-			esp_wifi_init(&cfg); //esp_wifi_set_country(&wifi_country);
+			esp_wifi_init(&cfg);
+            //esp_wifi_set_country(&wifi_country);
 			esp_wifi_set_storage(WIFI_STORAGE_RAM);
 			esp_wifi_set_mode(ESPNOW_WIFI_MODE);
-			esp_wifi_start(); // These two steps are required BEFORE the channel can be set
-			esp_wifi_set_promiscuous(true); // and this
+
+            // These two steps are required BEFORE the channel can be set
+			esp_wifi_start();
+			esp_wifi_set_promiscuous(true);
+
 			esp_wifi_set_channel(_channel, WIFI_SECOND_CHAN_NONE);
 			esp_now_init());
 			esp_now_register_send_cb(reinterpret_cast<esp_now_send_cb_t>(espnow_send_cb));
@@ -197,13 +196,11 @@ public:
 
 	void send_frame(uint8_t *data, uint16_t length, uint8_t dest_mac[ESP_NOW_ETH_ALEN]) {
 		if (!sendingDone) {
-			failCount++;
 			return; // we are still sending the previous frame - discard this one
 		}
 
 		uint8_t packet[ESPNOW_MAX_PACKET];
 		if (length + 4 > ESPNOW_MAX_PACKET) {
-			failCount++;
 			return;
 		}
 
@@ -223,9 +220,6 @@ public:
 				//delay(1);
 				yield(); 
 			} while(!sendingDone);
-		}
-		else {
-			failCount++;
 		}
   };
 

--- a/src/interfaces/ARDUINO/ESPNOWHelper.h
+++ b/src/interfaces/ARDUINO/ESPNOWHelper.h
@@ -4,10 +4,6 @@
 	#error "ESP8266 or ESP32 constant is not defined."
 #endif
 
-#include <stdlib.h>
-#include <time.h>
-#include <string.h>
-#include <assert.h>
 #include "PacketQueue.h"
 
 #if defined(ESP8266)
@@ -16,12 +12,14 @@
 	#include <ESP8266WiFi.h>
 #elif defined(ESP32)
 	#include <esp_now.h>
+	#include <nvs_flash.h>
+	#include <esp_wifi.h>
 #endif
 
 #if defined(CONFIG_STATION_MODE) // ESPNOW can work in both station and softap mode. It is configured in menuconfig.
 	#if defined(ESP8266)
 		#define ESPNOW_WIFI_MODE WIFI_STA
-        #define ESPNOW_WIFI_ROLE ESP_NOW_ROLE_CONTROLLER
+		#define ESPNOW_WIFI_ROLE ESP_NOW_ROLE_CONTROLLER
 	#elif defined(ESP32)
 		#define ESPNOW_WIFI_MODE WIFI_MODE_STA
 		#define ESPNOW_WIFI_IF ESP_IF_WIFI_STA
@@ -30,7 +28,7 @@
 #else
 	#if defined(ESP8266)
 		#define ESPNOW_WIFI_MODE WIFI_AP
-        #define ESPNOW_WIFI_ROLE ESP_NOW_ROLE_COMBO
+		#define ESPNOW_WIFI_ROLE ESP_NOW_ROLE_COMBO
 	#elif defined(ESP32)
 		#define ESPNOW_WIFI_MODE WIFI_MODE_AP
 		#define ESPNOW_WIFI_IF ESP_IF_WIFI_AP
@@ -120,7 +118,7 @@ public:
 		memcpy(_esp_pmk, espnow_pmk, 16);
 
 		#ifdef ESP8266
-            WiFi.mode(ESPNOW_WIFI_MODE);
+			WiFi.mode(ESPNOW_WIFI_MODE);
 			wifi_set_channel(_channel);
 			esp_now_init();
 			esp_now_set_self_role(ESPNOW_WIFI_ROLE);
@@ -130,19 +128,19 @@ public:
 			tcpip_adapter_init();
 			wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
 			esp_wifi_init(&cfg);
-            //esp_wifi_set_country(&wifi_country);
+			//esp_wifi_set_country(&wifi_country);
 			esp_wifi_set_storage(WIFI_STORAGE_RAM);
 			esp_wifi_set_mode(ESPNOW_WIFI_MODE);
 
-            // These two steps are required BEFORE the channel can be set
+			// These two steps are required BEFORE the channel can be set
 			esp_wifi_start();
 			esp_wifi_set_promiscuous(true);
 
 			esp_wifi_set_channel(_channel, WIFI_SECOND_CHAN_NONE);
-			esp_now_init());
+			esp_now_init();
 			esp_now_register_send_cb(reinterpret_cast<esp_now_send_cb_t>(espnow_send_cb));
 			esp_now_register_recv_cb(reinterpret_cast<esp_now_recv_cb_t>(espnow_recv_cb));
-			ESP_ERROR_CHECK(esp_now_set_pmk(_esp_pmk);
+			ESP_ERROR_CHECK(esp_now_set_pmk(_esp_pmk));
 		#endif
 
 		add_peer(espnow_broadcast_mac); // Add broadcast peer information to peer list

--- a/src/interfaces/ARDUINO/ESPNOWHelper.h
+++ b/src/interfaces/ARDUINO/ESPNOWHelper.h
@@ -1,56 +1,47 @@
 #pragma once
 
-#ifndef ESP32
-  #error "ESP32 constant is not defined."
+#if !defined(ESP8266) && !defined(ESP32)
+	#error "ESP8266 or ESP32 constant is not defined."
 #endif
 
-// ESP includes
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
 #include <assert.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/semphr.h"
-#include "freertos/timers.h"
-#include "nvs_flash.h"
-#include "esp_event_loop.h"
-#include "tcpip_adapter.h"
-#include "esp_wifi.h"
-#include "esp_log.h"
-#include "esp_system.h"
-#include "esp_now.h"
-#include "rom/ets_sys.h"
-#include "rom/crc.h"
-#include "esp_wifi_types.h"
+#include "PacketQueue.h"
 
-static const char *TAG = "espnow";
+#if defined(ESP8266)
+	#include <c_types.h>
+	#include <espnow.h>
+	#include <ESP8266WiFi.h>
+#elif defined(ESP32)
+	#include <esp_now.h>
+#endif
 
-/* ESPNOW can work in both station and softap mode.
-   It is configured in menuconfig. */
-#if CONFIG_STATION_MODE
-  #define ESPNOW_WIFI_MODE WIFI_MODE_STA
-  #define ESPNOW_WIFI_IF ESP_IF_WIFI_STA
+#if CONFIG_STATION_MODE // ESPNOW can work in both station and softap mode. It is configured in menuconfig.
+	#if defined(ESP8266)
+		#define ESPNOW_WIFI_MODE ESP_NOW_ROLE_CONTROLLER
+	#elif defined(ESP32)
+		#define ESPNOW_WIFI_MODE WIFI_MODE_STA
+		#define ESPNOW_WIFI_IF ESP_IF_WIFI_STA
+	#endif
+ 
 #else
-  #define ESPNOW_WIFI_MODE WIFI_MODE_AP
-  #define ESPNOW_WIFI_IF ESP_IF_WIFI_AP
+	#if defined(ESP8266)
+		#define ESPNOW_WIFI_MODE ESP_NOW_ROLE_COMBO
+	#elif defined(ESP32)
+		#define ESPNOW_WIFI_MODE WIFI_MODE_AP
+		#define ESPNOW_WIFI_IF ESP_IF_WIFI_AP
+	#endif
 #endif
 
 #define ESPNOW_MAX_PACKET 250
-#define ESPNOW_QUEUE_SIZE 6
+
 
 static uint8_t espnow_broadcast_mac[ESP_NOW_ETH_ALEN] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 #define IS_BROADCAST_ADDR(addr) (memcmp(addr, espnow_broadcast_mac, ESP_NOW_ETH_ALEN) == 0)
 
-typedef struct {
-  uint8_t mac_addr[ESP_NOW_ETH_ALEN];
-  esp_now_send_status_t status;
-} espnow_event_send_cb_t;
 
-typedef struct {
-  uint8_t mac_addr[ESP_NOW_ETH_ALEN];
-  uint8_t *data;
-  int data_len;
-} espnow_packet_t;
 
 enum {
   ESPNOW_DATA_BROADCAST,
@@ -59,192 +50,184 @@ enum {
 };
 
 static uint8_t last_mac[ESP_NOW_ETH_ALEN];
-static TaskHandle_t pjon_task_h = NULL;
-static xQueueHandle espnow_recv_queue = NULL;
+static PacketQueue packetQueue;
+volatile bool sendingDone = true;
 
-static void espnow_send_cb(const uint8_t *mac_addr, esp_now_send_status_t status) {
-  // The only thing we do in the send callback is unblock the
-  // other thread which blocks after posting data to the MAC
-  xTaskNotifyGive(pjon_task_h);
-  if(mac_addr == NULL) ESP_LOGE(TAG, "Send cb arg error");
-  return;
+static void espnow_send_cb(const uint8_t *mac_addr, uint8_t status) {
+	// The only thing we do in the send callback is unblock the other thread which blocks after posting data to the MAC
+	sendingDone = true; 
 };
 
 static void espnow_recv_cb(const uint8_t *mac_addr, const uint8_t *data, int len) {
-  espnow_packet_t packet;
-  if(mac_addr == NULL || data == NULL || len <= 0) {
-    ESP_LOGE(TAG, "Receive cb arg error");
-    return;
-  }
-  memcpy(packet.mac_addr, mac_addr, ESP_NOW_ETH_ALEN);
-  packet.data = (uint8_t *)malloc(len);
-  if(packet.data == NULL) {
-    ESP_LOGE(TAG, "Malloc receive data fail");
-    return;
-  }
-  memcpy(packet.data, data, len);
-  packet.data_len = len;
-  // Post to the queue, but don't wait
-  if(xQueueSend(espnow_recv_queue, &packet, 0) != pdTRUE) {
-    ESP_LOGW(TAG, "Send receive queue fail");
-    free(packet.data);
-  }
+	espnow_packet_t* packet = new espnow_packet_t();
+
+	memcpy(packet->mac_addr, mac_addr, ESP_NOW_ETH_ALEN);
+
+	packet->data = (uint8_t *)malloc(len);
+	memcpy(packet->data, data, len);
+	packet->data_len = len;
+
+	if (!packetQueue.push(packet)) { // queue is full - drop the packet
+		free(packet->data);
+		delete packet;
+	}
 };
 
 class ENHelper {
-  uint8_t _magic_header[4];
-  uint8_t _channel = 14;
-  uint8_t _esp_pmk[16];
+	uint8_t _magic_header[4];
+	uint8_t _channel = 14;
+	uint8_t _esp_pmk[16];
 
 public:
-  void add_node_mac(uint8_t mac_addr[ESP_NOW_ETH_ALEN]) {
-    ESP_ERROR_CHECK(add_peer(mac_addr));
+	void add_node_mac(uint8_t mac_addr[ESP_NOW_ETH_ALEN]) {
+		add_peer(mac_addr);
+	};
+
+	void add_peer(uint8_t mac_addr[ESP_NOW_ETH_ALEN]) {
+		if(esp_now_is_peer_exist(mac_addr))
+			return;
+
+		#if defined(ESP8266) // TODO: Fix encryption! ESP_NOW_ROLE_SLAVE doesn't seem to matter. From the doc: The peer's Role does not affect any function, but only stores the Role information for the application layer.
+			esp_now_add_peer(mac_addr, ESP_NOW_ROLE_SLAVE,_channel, NULL, 0); 
+
+		#elif defined(ESP32) // TODO: Why malloc a local variable? Add broadcast peer information to peer list.
+			esp_now_peer_info_t *peer = (esp_now_peer_info_t *)malloc(sizeof(esp_now_peer_info_t));
+
+			memset(peer, 0, sizeof(esp_now_peer_info_t));
+			peer->channel = _channel;
+			peer->ifidx = ESPNOW_WIFI_IF;
+			if(IS_BROADCAST_ADDR(mac_addr))
+				peer->encrypt = false; // else { peer->encrypt = true; memcpy(peer->lmk, _esp_pmk, 16); }
+			memcpy(peer->peer_addr, mac_addr, ESP_NOW_ETH_ALEN);
+			esp_now_add_peer(peer);
+			free(peer);
+		#endif
+	};
+
+	bool begin(uint8_t channel, uint8_t *espnow_pmk) {
+		 #if defined(ESP32) // TODO: Is this necessary?
+			esp_err_t ret = nvs_flash_init();
+			if(ret == ESP_ERR_NVS_NO_FREE_PAGES) {
+				ESP_ERROR_CHECK(nvs_flash_erase());
+				ret = nvs_flash_init();
+			}
+			ESP_ERROR_CHECK(ret);
+		#endif
+
+		_channel = channel;
+		memcpy(_esp_pmk, espnow_pmk, 16);
+
+		#ifdef ESP8266
+			WiFi.channel(_channel);
+			esp_now_init();
+			esp_now_set_self_role(ESPNOW_WIFI_MODE);
+			esp_now_register_send_cb(reinterpret_cast<esp_now_send_cb_t>(espnow_send_cb));
+			esp_now_register_recv_cb(reinterpret_cast<esp_now_recv_cb_t>(espnow_recv_cb));
+		#else
+			tcpip_adapter_init();
+			wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+			esp_wifi_init(&cfg); //esp_wifi_set_country(&wifi_country);
+			esp_wifi_set_storage(WIFI_STORAGE_RAM);
+			esp_wifi_set_mode(ESPNOW_WIFI_MODE);
+			esp_wifi_start(); // These two steps are required BEFORE the channel can be set
+			esp_wifi_set_promiscuous(true); // and this
+			esp_wifi_set_channel(_channel, WIFI_SECOND_CHAN_NONE);
+			esp_now_init());
+			esp_now_register_send_cb(reinterpret_cast<esp_now_send_cb_t>(espnow_send_cb));
+			esp_now_register_recv_cb(reinterpret_cast<esp_now_recv_cb_t>(espnow_recv_cb));
+			ESP_ERROR_CHECK(esp_now_set_pmk(_esp_pmk);
+		#endif
+
+		add_peer(espnow_broadcast_mac); // Add broadcast peer information to peer list
+
+		return true;
+	};
+
+	uint16_t receive_frame(uint8_t *data, uint16_t max_length) {
+		espnow_packet_t* packet = packetQueue.pop(); // see if there's any received data waiting
+		if (packet == NULL)
+			return PJON_FAIL;
+
+		if (packet->data_len < 4) { // The packet is too small
+			Serial.println("too small");
+			free(packet->data);
+			delete(packet);
+			return PJON_FAIL;
+		}
+
+		uint8_t len = packet->data_len - 4;
+
+		if(
+			(packet->data[0] ^ len) != _magic_header[0] ||
+			(packet->data[1] ^ len) != _magic_header[1] ||
+			(packet->data[packet->data_len - 2] ^ len) != _magic_header[2] ||
+			(packet->data[packet->data_len - 1] ^ len) != _magic_header[3]
+		) {
+			Serial.println("Magic mismatch");
+			free(packet->data);
+			delete(packet);
+			return PJON_FAIL;
+		}
+
+		//Serial.print("H"); Serial.println(packet->data[2]);
+
+		if (len > max_length) {
+			free(packet->data);
+			delete(packet);
+			return PJON_FAIL;
+		}
+
+		memcpy(last_mac, packet->mac_addr, ESP_NOW_ETH_ALEN);  // Update last received mac
+
+		memcpy(data, packet->data + 2, len);
+
+		free(packet->data);
+		delete(packet);
+
+		return len;
+	};
+
+	void send_frame(uint8_t *data, uint16_t length, uint8_t dest_mac[ESP_NOW_ETH_ALEN]) {
+		if (!sendingDone)
+			return; // we are still sending the previous frame - discard this one
+
+		uint8_t packet[ESPNOW_MAX_PACKET];
+		if (length + 4 > ESPNOW_MAX_PACKET) {
+			return;
+		}
+
+		uint8_t len = length;
+		packet[0] = _magic_header[0] ^ len;
+		packet[1] = _magic_header[1] ^ len;
+		memcpy(packet + 2, data, len);
+		packet[len + 2] = _magic_header[2] ^ len;
+		packet[len + 3] = _magic_header[3] ^ len;
+
+		ATOMIC()
+		{
+			sendingDone = false;
+		}
+		if(esp_now_send(dest_mac, packet, len + 4) == 0) {
+			do { // do nothing, wait for interrupt to be called
+				//delay(1);
+				yield(); 
+			} while(!sendingDone);
+		}
   };
 
-  esp_err_t add_peer(uint8_t mac_addr[ESP_NOW_ETH_ALEN]) {
-    if(esp_now_is_peer_exist(mac_addr))
-      return ESP_OK;
-    /* Add broadcast peer information to peer list. */
-    esp_now_peer_info_t *peer =
-        (esp_now_peer_info_t *)malloc(sizeof(esp_now_peer_info_t));
-    if(peer == NULL) {
-      ESP_LOGE(TAG, "Malloc peer information fail");
-      vSemaphoreDelete(espnow_recv_queue);
-      esp_now_deinit();
-      return ESP_FAIL;
-    }
-    memset(peer, 0, sizeof(esp_now_peer_info_t));
-    peer->channel = _channel;
-    peer->ifidx = ESPNOW_WIFI_IF;
-    if(IS_BROADCAST_ADDR(mac_addr))
-      peer->encrypt = false;
-    // else {
-    //   peer->encrypt = true;
-    //   memcpy(peer->lmk, _esp_pmk, 16);
-    // }
-    memcpy(peer->peer_addr, mac_addr, ESP_NOW_ETH_ALEN);
-    ESP_ERROR_CHECK(esp_now_add_peer(peer));
-    free(peer);
-    return ESP_OK;
-  };
+	void send_response(uint8_t response) {
+		send_frame(&response, 1, last_mac);
+	};
 
-  bool begin(uint8_t channel, uint8_t *espnow_pmk) {
-    esp_err_t ret = nvs_flash_init();
-    if(
-        ret == ESP_ERR_NVS_NO_FREE_PAGES // ||
-     // ret == ESP_ERR_NVS_NEW_VERSION_FOUND
-     // error: ESP_ERR_NVS_NEW_VERSION_FOUND was not declared in this scope
-    ) {
-      ESP_ERROR_CHECK(nvs_flash_erase());
-      ret = nvs_flash_init();
-    }
-    ESP_ERROR_CHECK(ret);
-    pjon_task_h = xTaskGetCurrentTaskHandle();
-    _channel = channel;
-    memcpy(_esp_pmk, espnow_pmk, 16);
-    if(espnow_recv_queue != NULL)
-      return ESP_FAIL;
-    espnow_recv_queue =
-        xQueueCreate(ESPNOW_QUEUE_SIZE, sizeof(espnow_packet_t));
-    if(espnow_recv_queue == NULL) {
-      ESP_LOGE(TAG, "Create mutex fail");
-      return ESP_FAIL;
-    }
-    tcpip_adapter_init();
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-    ESP_ERROR_CHECK(esp_wifi_set_country(&wifi_country));
-    ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
-    ESP_ERROR_CHECK(esp_wifi_set_mode(ESPNOW_WIFI_MODE));
-    /* These two steps are required BEFORE the channel can be set
-       As per the documentation from Espressif:
-     docs.espressif.com/projects/esp-idf/en/latest/api-reference/network/
-     esp_wifi.html#_CPPv420esp_wifi_set_channel7uint8_t18wifi_second_chan_t */
-    ESP_ERROR_CHECK(esp_wifi_start());
-    ESP_ERROR_CHECK(esp_wifi_set_promiscuous(true));
-    ESP_ERROR_CHECK(esp_wifi_set_channel(_channel, WIFI_SECOND_CHAN_NONE));
-    // Initialize ESPNOW and register sending & receiving callback function
-    ESP_ERROR_CHECK(esp_now_init());
-    ESP_ERROR_CHECK(esp_now_register_send_cb(espnow_send_cb));
-    ESP_ERROR_CHECK(esp_now_register_recv_cb(espnow_recv_cb));
-    // Set primary master key
-    ESP_ERROR_CHECK(esp_now_set_pmk(_esp_pmk));
-    // Add broadcast peer information to peer list
-    add_peer(espnow_broadcast_mac);
-    return true;
-  };
+	void send_frame(uint8_t *data, uint16_t length) { // Broadcast
+		send_frame(data, length, espnow_broadcast_mac);
+	};
 
-  uint16_t receive_frame(uint8_t *data, uint16_t max_length) {
-    // see if there's any received data waiting
-    espnow_packet_t packet;
-    if(xQueueReceive(espnow_recv_queue, &packet, 0) == pdTRUE) {
-      if(packet.data_len >= 4) {
-        uint8_t len = packet.data_len - 4;
-        if(
-          (packet.data[0] ^ len) != _magic_header[0] ||
-          (packet.data[1] ^ len) != _magic_header[1] ||
-          (packet.data[packet.data_len - 2] ^ len) != _magic_header[2] ||
-          (packet.data[packet.data_len - 1] ^ len) != _magic_header[3]
-        ) {
-          ESP_LOGE(TAG, "magic mismatch");
-          free(packet.data);
-          return PJON_FAIL;
-        }
-        if(len > max_length) {
-          free(packet.data);
-          ESP_LOGE(TAG, "buffer overflow - %d bytes but max is %d", len, max_length);
-          return PJON_FAIL;
-        }
-        memcpy(data, packet.data + 2, len);
-        free(packet.data);
-        // Update last mac received from
-        memcpy(last_mac, packet.mac_addr, ESP_NOW_ETH_ALEN);
-        return len;
-      } else {
-        ESP_LOGE(TAG, "packet < 4 received");
-        free(packet.data);
-        return PJON_FAIL; // No data waiting
-      }
-    }
-    return PJON_FAIL;
-  };
+	void set_magic_header(uint8_t *magic_header) {
+		memcpy(_magic_header, magic_header, 4);
+	};
 
-  void send_frame(
-    uint8_t *data,
-    uint16_t length,
-    uint8_t dest_mac[ESP_NOW_ETH_ALEN]
-  ) {
-    uint8_t packet[ESPNOW_MAX_PACKET];
-    if(length + 4 > ESPNOW_MAX_PACKET) {
-      ESP_LOGE(TAG, "Packet send error - too long :%d", length + 4);
-      return;
-    }
-    uint8_t len = length;
-    packet[0] = _magic_header[0] ^ len;
-    packet[1] = _magic_header[1] ^ len;
-    memcpy(packet + 2, data, len);
-    packet[len + 2] = _magic_header[2] ^ len;
-    packet[len + 3] = _magic_header[3] ^ len;
-    if(esp_now_send(dest_mac, packet, len + 4) != ESP_OK)
-      ESP_LOGE(TAG, "Send error");
-    else // Wait for notification that the data has been received by the MAC
-      ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-  };
-
-  void send_response(uint8_t response) {
-    send_frame(&response, 1, last_mac);
-  };
-
-  void send_frame(uint8_t *data, uint16_t length) {
-    // Broadcast
-    send_frame(data, length, espnow_broadcast_mac);
-  };
-
-  void set_magic_header(uint8_t *magic_header) {
-    memcpy(_magic_header, magic_header, 4);
-  };
-
-  void get_sender(uint8_t *ip) {
-    memcpy(ip, last_mac, ESP_NOW_ETH_ALEN);
-  };
+	void get_sender(uint8_t *ip) {
+		memcpy(ip, last_mac, ESP_NOW_ETH_ALEN);
+	};
 };

--- a/src/interfaces/ARDUINO/PacketQueue.h
+++ b/src/interfaces/ARDUINO/PacketQueue.h
@@ -13,7 +13,7 @@
     #define ESP_NOW_ETH_ALEN 6
 #endif
 
-#define ESPNOW_QUEUE_SIZE 200
+#define ESPNOW_QUEUE_SIZE 6
 
 typedef struct
 {

--- a/src/interfaces/ARDUINO/PacketQueue.h
+++ b/src/interfaces/ARDUINO/PacketQueue.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#if defined(ESP8266)
+    #include <c_types.h>
+    #include <espnow.h>
+#elif defined(ESP32)
+    #include <esp_now.h>
+#endif
+
+#include <SimplyAtomic.h> // https://github.com/wizard97/SimplyAtomic
+
+#ifndef ESP_NOW_ETH_ALEN
+    #define ESP_NOW_ETH_ALEN 6
+#endif
+
+#define ESPNOW_QUEUE_SIZE 200
+
+typedef struct
+{
+    uint8_t mac_addr[ESP_NOW_ETH_ALEN];
+    uint8_t *data;
+    int data_len;
+} espnow_packet_t;
+
+/**
+ * A queue of incoming packets of max capacity ESPNOW_QUEUE_SIZE.
+ * The queue should be atomic (not tested).
+ * This was done to remove a dependency on FreeRTOS - replacement of xQueueHandle (and related functions).
+ */
+class PacketQueue
+{
+    private:
+        espnow_packet_t* queue[ESPNOW_QUEUE_SIZE + 1];
+        volatile uint8_t firstElement = 0;
+        volatile uint8_t firstSpace = 0;
+        
+    public:
+        /**
+         * Adds a packet to the queue.
+         * @return true if successfull, false if the queue was full and the packet was not added.
+         */
+        bool push(espnow_packet_t* packet);
+
+        /**
+         * Remove the first packet from the queue and return it.
+         * @return first packet or NULL if the queue is empty
+         */
+        espnow_packet_t* pop();
+};
+
+bool PacketQueue::push(espnow_packet_t* packet)
+{   
+    bool isFull;
+
+    ATOMIC()
+    {
+        int firstSpacePlus1 = (firstSpace + 1) % ESPNOW_QUEUE_SIZE;
+        isFull = firstSpacePlus1 == firstElement;
+        if (!isFull)
+        {
+            queue[firstSpace] = packet;
+            firstSpace = firstSpacePlus1;
+        }
+    }
+
+    return !isFull;
+}
+
+espnow_packet_t* PacketQueue::pop() {
+    if (firstElement == firstSpace) {
+        return NULL;
+    }
+    else
+    {
+        espnow_packet_t* packet;
+
+        ATOMIC()
+        {
+            packet = queue[firstElement];
+            firstElement = (firstElement + 1) % ESPNOW_QUEUE_SIZE;
+        }
+
+        return packet;
+    }
+}

--- a/src/strategies/ESPNOW/ESPNOW.h
+++ b/src/strategies/ESPNOW/ESPNOW.h
@@ -76,7 +76,7 @@ class ESPNOW {
         PJONTools::parse_header(message, packet_info);
         uint8_t sender_id = packet_info.tx.id;
         if(sender_id == 0) {
-          ESP_LOGE("ESPNOW", "AutoRegister parsing failed");
+          //ESP_LOGE("ESPNOW", "AutoRegister parsing failed");
           return; // If parsing fails, it will be 0
         }
 
@@ -87,19 +87,19 @@ class ESPNOW {
         // See if PJON id is already registered, add if not
         int16_t pos = find_remote_node(sender_id);
         if(pos == -1) {
-          ESP_LOGI("ESPNOW", "Autoregister new sender %d",sender_id);
+          //ESP_LOGI("ESPNOW", "Autoregister new sender %d",sender_id);
           add_node(sender_id, sender_mac);
         }
         else if(memcmp(_remote_mac[pos], sender_mac, ESP_NOW_ETH_ALEN) != 0) {
           // Update mac of existing node
-          ESP_LOGI(
+          /*ESP_LOGI(
             "ESPNOW",
             "Update sender mac %d %d:%d:%d",
             sender_id,
             sender_mac[1],
             sender_mac[2],
             sender_mac[3]
-          );
+          );*/
           memcpy(_remote_mac[pos], sender_mac, ESP_NOW_ETH_ALEN);
         }
       }
@@ -194,6 +194,8 @@ public:
         if(reply_length == 1)
           if(result[0] == PJON_ACK)
             return result[0];
+
+        yield();
 
       } while ((uint32_t)(PJON_MICROS() - start) < EN_RESPONSE_TIMEOUT);
       return PJON_FAIL;

--- a/src/strategies/ESPNOW/ESPNOW.h
+++ b/src/strategies/ESPNOW/ESPNOW.h
@@ -76,7 +76,9 @@ class ESPNOW {
         PJONTools::parse_header(message, packet_info);
         uint8_t sender_id = packet_info.tx.id;
         if(sender_id == 0) {
-          //ESP_LOGE("ESPNOW", "AutoRegister parsing failed");
+          #if defined(ESP32)  
+            ESP_LOGE("ESPNOW", "AutoRegister parsing failed");
+          #endif
           return; // If parsing fails, it will be 0
         }
 
@@ -87,19 +89,23 @@ class ESPNOW {
         // See if PJON id is already registered, add if not
         int16_t pos = find_remote_node(sender_id);
         if(pos == -1) {
-          //ESP_LOGI("ESPNOW", "Autoregister new sender %d",sender_id);
+          #if defined(ESP32)
+            ESP_LOGI("ESPNOW", "Autoregister new sender %d",sender_id);
+          #endif
           add_node(sender_id, sender_mac);
         }
         else if(memcmp(_remote_mac[pos], sender_mac, ESP_NOW_ETH_ALEN) != 0) {
           // Update mac of existing node
-          /*ESP_LOGI(
-            "ESPNOW",
-            "Update sender mac %d %d:%d:%d",
-            sender_id,
-            sender_mac[1],
-            sender_mac[2],
-            sender_mac[3]
-          );*/
+          #if defined(ESP32)
+            ESP_LOGI(
+                "ESPNOW",
+                "Update sender mac %d %d:%d:%d",
+                sender_id,
+                sender_mac[1],
+                sender_mac[2],
+                sender_mac[3]
+            );
+          #endif
           memcpy(_remote_mac[pos], sender_mac, ESP_NOW_ETH_ALEN);
         }
       }

--- a/src/strategies/ESPNOW/README.md
+++ b/src/strategies/ESPNOW/README.md
@@ -4,7 +4,7 @@
 |--------|-----------|--------------------|
 | ESPNOW over WiFi   | NA    | `#include <PJONESPNOW.h>` |
 
-With the `ESPNOW` PJON strategy, up to 10 ESP32 devices can use PJON to communicate with each other over
+With the `ESPNOW` PJON strategy, up to 10 ESP32 or ESP8266 devices can use PJON to communicate with each other over
 the [Espressif ESPNOW protocol](https://www.espressif.com/en/products/software/esp-now/overview) (peer-to-peer 802.11).
 
 PJON over ESPNOW has the following benefits:
@@ -37,6 +37,13 @@ void setup() {
   bus.strategy.set_pmk(pmk);
 }
 ```
+
+You can also choose between Access Point and Station mode. To switch to Station mode, define CONFIG_STATION_MODE before
+including PJONESPNOW.h.
+```cpp
+    #define CONFIG_STATION_MODE
+    #include <PJONESPNOW.h>
+``` 
 
 The ESPNOW strategy will send a broadcast message if the device_id is not already registered. Once a response is received (assuming auto-registration is enabled) the device automatically adds the node id and mac in its table. Sender auto-registration is enabled by default and can be disabled using the following setter:
 


### PR DESCRIPTION
Hi!
I have ported ESP-NOW strategy to support esp8266. I am a newbie in microcontroller development and it's a long time since I wrote C++. Could you please go over the change carefully and tell me if you spot any mistakes or imperfections? Also, I did some changes to ESP32 code but I have not tested it works for ESP32. Could you please double check it? I have tried out only a very basic scenario for ESP8266, which seems to work.

I have removed the dependency on FreeRTOS and replaced it with one volatile bool variable and my own class PacketQueue. I have introduced a new dependency on SimplyAtomic https://github.com/wizard97/SimplyAtomic Is this OK? How to change the project to include this dependency? The got a feeling that the dependency might not be really necessary, could you have a look at how I used ATOMIC() macro in the code and advice if this is possible and how to do it?

Also, I have removed a bunch of error logging function calls, which seems to be missing in ESP8266 (is this really true?). Is this an OK thing to do?

Thank you for your help and for developing PJON! It's a great work :)