### PR TITLE
interface/linux: delayMicroseconds changed to use select to avoid CPU…

### DIFF
--- a/src/interfaces/LINUX/PJON_LINUX_Interface.h
+++ b/src/interfaces/LINUX/PJON_LINUX_Interface.h
@@ -36,6 +36,7 @@
   #include <chrono>
   #include <thread>
   #include <sstream>
+  #include <math.h>
 
   #define OUTPUT 1
   #define INPUT 0

--- a/src/interfaces/LINUX/PJON_LINUX_Interface.inl
+++ b/src/interfaces/LINUX/PJON_LINUX_Interface.inl
@@ -30,15 +30,17 @@ uint32_t millis() {
 };
 
 void delayMicroseconds(uint32_t delay_value) {
-  auto begin_ts = std::chrono::high_resolution_clock::now();
-  while(true) {
-    auto elapsed_usec =
-    std::chrono::duration_cast<std::chrono::microseconds>(
-      std::chrono::high_resolution_clock::now() - begin_ts
-    ).count();
-    if(elapsed_usec >= delay_value) break;
-    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  struct timeval tv;
+  if (delay_value < 1000000){
+    tv.tv_sec = 0;
+    tv.tv_usec = delay_value;
   }
+  else{ 
+    tv.tv_sec = floor(delay_value / 1000000); 
+    tv.tv_usec = delay_value - tv.tv_sec * 1000000;
+  }
+ 
+  select(0, NULL, NULL, NULL, &tv);
 };
 
 void delay(uint32_t delay_value_ms) {


### PR DESCRIPTION
The delayMicroseconds function from Linux interface (probably taken from Win32 interface implementation) loads CPU significantly on an amd64 Centos 7. This PR changes implementation to use non-blocking select. 

BTW in the current master the Linux interface code uses usleep function which is obsolete (source: https://linux.die.net/man/3/usleep) and  could be replaced with this delayMicroseconds. It would be even better to replace delayMicroseconds with nanosleep().  