### PR TITLE
Limited scope of some Windows-specific defines for LocalFile strategy

### DIFF
--- a/src/strategies/LocalFile/FileLockFunctions.h
+++ b/src/strategies/LocalFile/FileLockFunctions.h
@@ -233,5 +233,12 @@ int LockFileSection(const int iFileNo,       // the fileno
 #undef W_OK
 #undef R_OK
 #undef X_OK
+#undef access
+#undef lseek
+#undef locking
+#undef open
+#undef write
+#undef read
+#undef close
 #endif
 


### PR DESCRIPTION
Could casue conflicts in other headers included later