### PR TITLE
Prevent linking errors: Inline LINUX_Interface functions and remove global vars

### DIFF
--- a/src/interfaces/LINUX/PJON_LINUX_Interface.inl
+++ b/src/interfaces/LINUX/PJON_LINUX_Interface.inl
@@ -8,30 +8,39 @@
 #include "PJON_LINUX_Interface.h"
 #include "/usr/include/asm-generic/termbits.h"
 #include "/usr/include/asm-generic/ioctls.h"
+#include <chrono>
 
-auto start_ts = std::chrono::high_resolution_clock::now();
-auto start_ts_ms = std::chrono::high_resolution_clock::now();
+inline auto& getMutableStartTime()
+{
+    static auto start_ts = std::chrono::high_resolution_clock::now();
+    return start_ts;
+}
+inline auto getStartTime()
+{
+    static auto start_ts_ms = std::chrono::high_resolution_clock::now();
+    return start_ts_ms;
+}
 
-uint32_t micros() {
+inline uint32_t micros() {
   auto elapsed_usec =
   std::chrono::duration_cast<std::chrono::microseconds>(
-    std::chrono::high_resolution_clock::now() - start_ts
+    std::chrono::high_resolution_clock::now() - getMutableStartTime()
   ).count();
 
   if(elapsed_usec >= UINT32_MAX) {
-    start_ts = std::chrono::high_resolution_clock::now();
+    getMutableStartTime() = std::chrono::high_resolution_clock::now();
     return 0;
   } else return elapsed_usec;
 };
 
-uint32_t millis() {
+inline uint32_t millis() {
   return (uint32_t)
   std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::high_resolution_clock::now() - start_ts_ms
+    std::chrono::high_resolution_clock::now() - getStartTime()
   ).count();
 };
 
-void delayMicroseconds(uint32_t delay_value) {
+inline void delayMicroseconds(uint32_t delay_value) {
   struct timeval tv;
   if (delay_value < 1000000){
     tv.tv_sec = 0;
@@ -45,13 +54,13 @@ void delayMicroseconds(uint32_t delay_value) {
   select(0, NULL, NULL, NULL, &tv);
 };
 
-void delay(uint32_t delay_value_ms) {
+inline void delay(uint32_t delay_value_ms) {
   std::this_thread::sleep_for(std::chrono::milliseconds(delay_value_ms));
 };
 
 /* Open serial port ----------------------------------------------------- */
 
-int serialOpen(const char *device, const int baud) {
+inline int serialOpen(const char *device, const int baud) {
   speed_t bd;
   int fd;
 
@@ -98,7 +107,7 @@ int serialOpen(const char *device, const int baud) {
 
 /* Returns the number of bytes of data available to be read in the buffer */
 
-int serialDataAvailable(const int fd) {
+inline int serialDataAvailable(const int fd) {
   int result = 0;
   ioctl(fd, FIONREAD, &result);
   return result;
@@ -106,7 +115,7 @@ int serialDataAvailable(const int fd) {
 
 /* Reads a character from the serial buffer ------------------------------- */
 
-int serialGetCharacter(const int fd) {
+inline int serialGetCharacter(const int fd) {
   uint8_t result;
   if(read(fd, &result, 1) != 1) return -1;
   return ((int)result) & 0xFF;


### PR DESCRIPTION
This prevents linking errors if PJON is included in multiple compilation units.
Also using the static singleton pattern is safer than global vars, especially with multiple compilation units.

Currently projects cannot be linked if PJON.h is included in more than one cpp file, as global vars and function definitions will be there multiple times and cause conflicts.

One solution would be to separate function declarations and definitions into .h[pp] and .cpp files, however in your project you do not seem to use cpp files at all and also do not have a build system set up.
So to fix this I just used _inlining_ and the static singleton pattern (for global vars). This will effectively prevent linking errors (might cause some codesize increase).