### PR TITLE
Fix undefined behavior when using ports #406

### DIFF
--- a/src/PJONDefines.h
+++ b/src/PJONDefines.h
@@ -395,6 +395,14 @@ struct PJONTools {
 
   static void parse_header(const uint8_t *packet, PJON_Packet_Info &info) {
     uint8_t index = 0;
+
+    // replace passed in info with a fresh instance
+    // (initializing all values to their defaults)
+    // This is important, as we conditionally parse some info fields (e.g. Port)
+    // Those would then be left uninitialized or in an old state corresponding to
+    // the previous packet:
+    info = PJON_Packet_Info{};
+
     info.rx.id = packet[index++];
     bool extended_length = packet[index] & PJON_EXT_LEN_BIT;
     info.header = packet[index++];


### PR DESCRIPTION
fixes #406 
I tested this in my setup, using port 0,1 and 2. Now receiving works again :)
I also implemented it a little bit different that proposed in the issue.
I now use explicit re-initialization of the PacketInfo variable to avoid similar problems in other scenarios (packet-id, bus-id) which in my opinition might suffer from the same problem.