### PR TITLE
Fix ESPNow strategy to address breaking changes in ESP32 core

### DIFF
--- a/src/interfaces/ARDUINO/ESPNOWHelper.h
+++ b/src/interfaces/ARDUINO/ESPNOWHelper.h
@@ -29,10 +29,10 @@ static const char *TAG = "espnow";
    It is configured in menuconfig. */
 #if CONFIG_STATION_MODE
   #define ESPNOW_WIFI_MODE WIFI_MODE_STA
-  #define ESPNOW_WIFI_IF ESP_IF_WIFI_STA
+  #define ESPNOW_WIFI_IF WIFI_IF_STA
 #else
   #define ESPNOW_WIFI_MODE WIFI_MODE_AP
-  #define ESPNOW_WIFI_IF ESP_IF_WIFI_AP
+  #define ESPNOW_WIFI_IF WIFI_IF_AP
 #endif
 
 #define ESPNOW_MAX_PACKET 250


### PR DESCRIPTION
The ESPNow strategy uses old wifi_interface_t enums that have been removed/renamed in current version of ESP core, which causes compilation to fail  (believe these were first introduced in esp32 core v1.0.5)
Attached PR makes simple updates to address this, tested using the latest Arduino ESP32 v2.0.5 target board (based on ESP IDF Core v4.4.2), which makes the example compile and run (although some weirdness still remains, so it's possible that other changes are also required to update the strategy to current version)


